### PR TITLE
Implement cancelation when starting new campaign

### DIFF
--- a/hyatt-gpt-prototype/public/index.html
+++ b/hyatt-gpt-prototype/public/index.html
@@ -881,6 +881,10 @@
                 <button id="deliverablesBtn" onclick="openDeliverablesPanel()" style="display: none; background: #667eea; color: white; border: none; padding: 8px 16px; border-radius: 20px; margin-top: 10px; margin-left: 10px; cursor: pointer;">
                     View Deliverables
                 </button>
+
+                <button id="newCampaignBtn" onclick="startNewCampaign()" style="display: none; background: #ffc107; color: black; border: none; padding: 8px 16px; border-radius: 20px; margin-top: 10px; margin-left: 10px; cursor: pointer;">
+                    New Campaign
+                </button>
                 
                 <!-- Progress Updates Section (Hidden - now in side panel) -->
                 <div id="progressUpdates" class="progress-updates" style="display: none;">
@@ -991,12 +995,40 @@
         let currentPhase = null; // Track current phase
         let phaseStartTime = null; // Track phase timing
 
+        async function startNewCampaign() {
+            if (currentCampaignId) {
+                try {
+                    await fetch(`/api/campaigns/${currentCampaignId}`, { method: 'DELETE' });
+                } catch (e) {
+                    console.error('Failed to cancel campaign', e);
+                }
+                if (pollingInterval) clearInterval(pollingInterval);
+                pollingInterval = null;
+            }
+
+            currentCampaignId = null;
+            progressMessages = [];
+            lastProgressCount = 0;
+            campaignDeliverables = {};
+            updateDeliverablesPanel();
+
+            document.getElementById('campaignId').innerHTML = '<div class="campaign-id">No active campaign</div>';
+            document.getElementById('progressBtn').style.display = 'none';
+            document.getElementById('deliverablesBtn').style.display = 'none';
+            document.getElementById('newCampaignBtn').style.display = 'none';
+            document.getElementById('progressMessages').innerHTML = '';
+            document.getElementById('progressPanelMessages').innerHTML = '';
+            document.getElementById('conversationMessages').innerHTML = '';
+        }
+
         async function createCampaign() {
             // Prevent multiple submissions
             if (isCreatingCampaign) {
                 console.log('Campaign creation already in progress, ignoring duplicate request');
                 return;
             }
+
+            document.getElementById('newCampaignBtn').style.display = 'none';
 
             // Clear previous campaign deliverables
             campaignDeliverables = {};
@@ -1058,6 +1090,8 @@
                     
                     // Start polling for updates immediately
                     startPolling();
+
+                    document.getElementById('newCampaignBtn').style.display = 'inline-block';
                     
                     // Also do an immediate poll
                     setTimeout(updateCampaignStatus, 2000); // Increased delay
@@ -1676,8 +1710,9 @@
                     results.style.display = 'none';
                 }
             });
-            
+
             startPolling();
+            document.getElementById('newCampaignBtn').style.display = 'inline-block';
         }
 
         // Initialize page

--- a/hyatt-gpt-prototype/server.js
+++ b/hyatt-gpt-prototype/server.js
@@ -233,6 +233,16 @@ app.get("/api/campaigns", async (req, res) => {
   }
 });
 
+// Cancel and remove a campaign
+app.delete("/api/campaigns/:id", (req, res) => {
+  const { id } = req.params;
+  const cancelled = orchestrator.cancelCampaign(id);
+  if (!cancelled) {
+    return res.status(404).json({ error: "Campaign not found" });
+  }
+  res.json({ status: "cancelled", campaignId: id });
+});
+
 // Serve the frontend
 app.get("/", (req, res) => {
   res.sendFile(path.join(__dirname, "public", "index.html"));


### PR DESCRIPTION
## Summary
- add campaign timer tracking and cancellation helpers
- provide API endpoint to cancel campaigns
- update UI with `New Campaign` button and cancel workflow logic

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6840670a97588325aa7cf4510ccaa418