### PR TITLE
Add manual review toggle

### DIFF
--- a/hyatt-gpt-prototype/public/index.html
+++ b/hyatt-gpt-prototype/public/index.html
@@ -12,6 +12,13 @@
             <h1>🏨 Hyatt GPT Agents System</h1>
             <p>Collaborative AI agents for PR campaign development</p>
             <button class="btn" id="newCampaignBtn" onclick="newCampaign()" style="display:none; margin-left:20px;">New Campaign</button>
+            <button class="settings-btn" id="settingsBtn" onclick="toggleSettings()">⚙️</button>
+            <div class="settings-popup" id="settingsPopup">
+                <label>
+                    <input type="checkbox" id="manualReviewCheckbox" onchange="toggleManualReview()">
+                    Enable Manual Review
+                </label>
+            </div>
         </div>
 
         <div class="main-content">

--- a/hyatt-gpt-prototype/public/script.js
+++ b/hyatt-gpt-prototype/public/script.js
@@ -751,6 +751,14 @@
                 renderProgressPanel();
             }
 
+            fetch('/api/manual-review')
+                .then(res => res.json())
+                .then(data => {
+                    const cb = document.getElementById('manualReviewCheckbox');
+                    if (cb) cb.checked = data.enabled;
+                })
+                .catch(() => {});
+
             // ADDED: Event listener for conversation scroll
             const conversationMessages = document.getElementById('conversationMessages');
             if (conversationMessages) {
@@ -935,3 +943,30 @@
             document.getElementById('campaignForm').style.display = 'block';
             document.getElementById('newCampaignBtn').style.display = 'none';
         }
+
+        function toggleSettings() {
+            const popup = document.getElementById('settingsPopup');
+            popup.classList.toggle('show');
+        }
+
+        async function toggleManualReview() {
+            const checkbox = document.getElementById('manualReviewCheckbox');
+            try {
+                await fetch('/api/manual-review', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ enabled: checkbox.checked })
+                });
+            } catch (err) {
+                alert('Failed to update manual review setting');
+                checkbox.checked = !checkbox.checked;
+            }
+        }
+
+        window.addEventListener('click', function(e) {
+            const popup = document.getElementById('settingsPopup');
+            const btn = document.getElementById('settingsBtn');
+            if (!popup.contains(e.target) && e.target !== btn) {
+                popup.classList.remove('show');
+            }
+        });

--- a/hyatt-gpt-prototype/public/style.css
+++ b/hyatt-gpt-prototype/public/style.css
@@ -41,6 +41,31 @@
             color: #495057;
         }
 
+        .settings-btn {
+            background: none;
+            border: none;
+            font-size: 1.2rem;
+            margin-left: 10px;
+            cursor: pointer;
+        }
+
+        .settings-popup {
+            position: absolute;
+            right: 20px;
+            top: 70px;
+            background: #ffffff;
+            border: 1px solid #e9ecef;
+            padding: 10px 15px;
+            border-radius: 8px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+            display: none;
+            z-index: 1005;
+        }
+
+        .settings-popup.show {
+            display: block;
+        }
+
         .container {
             max-width: 1200px;
             margin: 0 auto;

--- a/hyatt-gpt-prototype/server.js
+++ b/hyatt-gpt-prototype/server.js
@@ -48,6 +48,17 @@ const orchestrator = new AgentOrchestrator();
 
 // Routes
 
+// Manual review status
+app.get("/api/manual-review", (req, res) => {
+  res.json({ enabled: orchestrator.enableManualReview });
+});
+
+app.post("/api/manual-review", (req, res) => {
+  const { enabled } = req.body;
+  orchestrator.enableManualReview = !!enabled;
+  res.json({ enabled: orchestrator.enableManualReview });
+});
+
 // Health check
 app.get("/health", (req, res) => {
   res.json({


### PR DESCRIPTION
## Summary
- add settings popup with Manual Review toggle
- wire toggle API calls in `script.js`
- style new settings controls
- expose `/api/manual-review` endpoint

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6840743900008325ba1f99edcc4b3803