### PR TITLE
Add manual review workflow

### DIFF
--- a/hyatt-gpt-prototype/AgentOrchestrator.js
+++ b/hyatt-gpt-prototype/AgentOrchestrator.js
@@ -1456,6 +1456,12 @@ class AgentOrchestrator {
       campaign.pendingPhase = nextPhase;
       campaign.awaitingReview = awaitingMap[nextPhase];
       campaign.lastUpdated = new Date().toISOString();
+      campaign.conversation.push({
+        speaker: "PR Manager",
+        message:
+          `Campaign is paused for manual review after the ${campaign.awaitingReview} phase. Choose \"Resume\" to continue to ${nextPhase} or \"Refine\" to adjust instructions.`,
+        timestamp: new Date().toISOString(),
+      });
       this.saveCampaignToFile(campaign);
       return;
     }

--- a/hyatt-gpt-prototype/docs/README.md
+++ b/hyatt-gpt-prototype/docs/README.md
@@ -171,6 +171,17 @@ MIN_STORY_ANGLE_STRENGTH=80
 REQUIRE_DATA_VALIDATION=true
 ```
 
+### HITL Manual Review
+
+```bash
+ENABLE_MANUAL_REVIEW=true
+```
+
+When manual review is enabled the orchestrator pauses after each phase.
+The web UI shows a banner describing which phase is awaiting approval.
+Click **Resume** to continue with the next phase or **Refine** to restart the
+campaign with updated instructions.
+
 ## 🔄 Dynamic Flow Examples
 
 ### Standard Flow

--- a/hyatt-gpt-prototype/public/index.html
+++ b/hyatt-gpt-prototype/public/index.html
@@ -62,6 +62,12 @@
                 <button id="newCampaignBtn" onclick="startNewCampaign()" style="display: none; background: #ffc107; color: black; border: none; padding: 8px 16px; border-radius: 20px; margin-top: 10px; margin-left: 10px; cursor: pointer;">
                     New Campaign
                 </button>
+
+                <div id="reviewBanner" class="review-banner" style="display:none;">
+                    <p id="reviewMessage"></p>
+                    <button id="resumeBtn" class="btn">Resume</button>
+                    <button id="refineBtn" class="btn btn-refine">Refine</button>
+                </div>
                 
                 <!-- Progress Updates Section (Hidden - now in side panel) -->
                 <div id="progressUpdates" class="progress-updates" style="display: none;">

--- a/hyatt-gpt-prototype/public/script.js
+++ b/hyatt-gpt-prototype/public/script.js
@@ -7,6 +7,7 @@
         let campaignInProgress = false; // Track if a campaign is running
         let currentPhase = null; // Track current phase
         let phaseStartTime = null; // Track phase timing
+        let reviewBannerVisible = false;
 
         async function startNewCampaign() {
             if (currentCampaignId) {
@@ -362,6 +363,12 @@
                 if (response.ok) {
                     updateConversationFlow(campaign);
                     simulateProgressFromConversation(campaign);
+
+                    if (campaign.status === 'paused') {
+                        showReviewBanner(campaign);
+                    } else {
+                        hideReviewBanner();
+                    }
 
                     if (campaign.status === 'completed') {
                         clearInterval(pollingInterval);
@@ -882,6 +889,34 @@
             setTimeout(() => {
                 deliverablesBtn.style.animation = '';
             }, 2000);
+        }
+
+        function showReviewBanner(campaign) {
+            const banner = document.getElementById('reviewBanner');
+            const msg = document.getElementById('reviewMessage');
+            msg.textContent = `Awaiting review of the ${campaign.awaitingReview} phase.`;
+            banner.style.display = 'block';
+            reviewBannerVisible = true;
+
+            document.getElementById('resumeBtn').onclick = async () => {
+                try {
+                    await fetch(`/api/campaigns/${campaign.id}/resume`, { method: 'POST' });
+                } catch (err) {
+                    alert('Failed to resume campaign');
+                }
+            };
+
+            document.getElementById('refineBtn').onclick = () => {
+                startNewCampaign();
+                banner.style.display = 'none';
+            };
+        }
+
+        function hideReviewBanner() {
+            if (!reviewBannerVisible) return;
+            const banner = document.getElementById('reviewBanner');
+            banner.style.display = 'none';
+            reviewBannerVisible = false;
         }
 
         function toggleCampaignsList() {

--- a/hyatt-gpt-prototype/public/style.css
+++ b/hyatt-gpt-prototype/public/style.css
@@ -175,6 +175,22 @@
             transform: none;
         }
 
+        .review-banner {
+            background: #fff3cd;
+            border: 1px solid #ffeeba;
+            padding: 10px 15px;
+            border-radius: 8px;
+            margin-top: 15px;
+        }
+
+        .review-banner p {
+            margin-bottom: 10px;
+        }
+
+        .btn-refine {
+            background: #e83e8c;
+        }
+
         .status-section {
             margin-top: 30px;
         }


### PR DESCRIPTION
## Summary
- pause campaigns with PR Manager message when manual review is enabled
- show HITL banner on the frontend with Resume and Refine options
- support pause status detection in polling logic
- style review banner and document manual review workflow

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68407b86f5ec8325a04fc9373282767b