### PR TITLE
Fix manual review per campaign

### DIFF
--- a/hyatt-gpt-prototype/AgentOrchestrator.js
+++ b/hyatt-gpt-prototype/AgentOrchestrator.js
@@ -1445,7 +1445,7 @@ class AgentOrchestrator {
     const campaign = this.campaigns.get(campaignId);
     if (!campaign) return;
 
-    if (this.enableManualReview) {
+    if (campaign.manualReview) {
       const awaitingMap = {
         strategic_insight: "research",
         trending: "strategic_insight",


### PR DESCRIPTION
## Summary
- ensure campaign-level `manualReview` is honored when scheduling phases

## Testing
- `npm test` *(fails: jest not found)*
- `node` script to schedule phases *(fails: module uuid not found)*

------
https://chatgpt.com/codex/tasks/task_b_684083358ab88325881680b0de70b428