### PR TITLE
Fix progress panel initial scroll

### DIFF
--- a/hyatt-gpt-prototype/public/script.js
+++ b/hyatt-gpt-prototype/public/script.js
@@ -784,8 +784,19 @@
 
         // Progress Panel Functions - LEFT SIDE
         function openProgressPanel() {
-            document.getElementById('progressPanel').classList.add('open');
+            const panel = document.getElementById('progressPanel');
+            panel.classList.add('open');
             updateContainerClasses();
+
+            // When opening the panel, ensure the latest messages are rendered
+            // and automatically scroll to the bottom so the newest updates are
+            // visible. This mirrors the behaviour when new messages arrive but
+            // still allows the user to scroll up manually afterwards.
+            renderProgressPanel();
+            const container = document.getElementById('progressPanelMessages');
+            if (container) {
+                container.scrollTop = container.scrollHeight;
+            }
         }
 
         function closeProgressPanel() {


### PR DESCRIPTION
## Summary
- ensure `Campaign Progress` panel scrolls to the latest update when opened

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6840a50a07a48325a76d24cb355ab6ce