### PR TITLE
Remove manual resume alert

### DIFF
--- a/hyatt-gpt-prototype/public/script.js
+++ b/hyatt-gpt-prototype/public/script.js
@@ -905,7 +905,6 @@
 
         function showReviewBanner(campaign) {
             addReviewPrompt(campaign);
-            alert('If you cannot see the Resume button, please scroll to the bottom of the conversation.');
         }
 
         function hideReviewBanner() {


### PR DESCRIPTION
## Summary
- clean up UI by removing intrusive resume alert

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6840ada00cb483259308be182874aae1