### PR TITLE
Update refine flow

### DIFF
--- a/hyatt-gpt-prototype/docs/README.md
+++ b/hyatt-gpt-prototype/docs/README.md
@@ -180,7 +180,9 @@ ENABLE_MANUAL_REVIEW=true  # default (set to false to disable)
 When manual review is enabled the orchestrator pauses after each phase.
 The conversation flow now displays a prompt describing which phase is awaiting
 approval. Use **Resume** (or **Finalize** for the last step) to continue or
-select **Refine** to restart the campaign with updated instructions.
+select **Refine** to provide new instructions. The system will ask how you
+want to adjust the deliverable and then rerun the current phase with your
+updates.
 
 ## 🔄 Dynamic Flow Examples
 

--- a/hyatt-gpt-prototype/public/script.js
+++ b/hyatt-gpt-prototype/public/script.js
@@ -945,14 +945,53 @@
             };
 
             document.getElementById('refineBtnFlow').onclick = () => {
-                startNewCampaign();
                 removeReviewPrompt();
+                showRefinePrompt(campaign.id);
             };
         }
 
         function removeReviewPrompt() {
             const prompt = document.getElementById('reviewPrompt');
             if (prompt) prompt.remove();
+        }
+
+        function showRefinePrompt(campaignId) {
+            const container = document.getElementById('conversationMessages');
+            if (!container || document.getElementById('refinePrompt')) return;
+
+            const prompt = document.createElement('div');
+            prompt.id = 'refinePrompt';
+            prompt.className = 'review-prompt';
+            prompt.innerHTML = `
+                <div class="review-prompt-text">Enter refinement instructions:</div>
+                <textarea id="refineText" rows="3" style="width:100%; margin-top:10px;"></textarea>
+                <div class="review-prompt-actions">
+                    <button id="submitRefine" class="btn btn-refine">Submit</button>
+                    <button id="cancelRefine" class="btn">Cancel</button>
+                </div>
+            `;
+
+            container.appendChild(prompt);
+            scrollToConversationBottom();
+
+            document.getElementById('submitRefine').onclick = async () => {
+                const text = document.getElementById('refineText').value.trim();
+                if (!text) return;
+                try {
+                    await fetch(`/api/campaigns/${campaignId}/refine`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ instructions: text })
+                    });
+                } catch (err) {
+                    alert('Failed to submit refinement');
+                }
+                prompt.remove();
+            };
+
+            document.getElementById('cancelRefine').onclick = () => {
+                prompt.remove();
+            };
         }
 
         function toggleCampaignsList() {

--- a/hyatt-gpt-prototype/public/style.css
+++ b/hyatt-gpt-prototype/public/style.css
@@ -189,9 +189,18 @@
             margin-top: 10px;
         }
 
-        .review-prompt-actions .btn {
-            margin: 0 5px;
-        }
+.review-prompt-actions .btn {
+    margin: 0 5px;
+}
+
+.review-prompt textarea {
+    width: 100%;
+    margin-top: 10px;
+    padding: 8px;
+    border-radius: 4px;
+    border: 1px solid #ccc;
+    resize: vertical;
+}
 
 
         .btn-refine {

--- a/hyatt-gpt-prototype/server.js
+++ b/hyatt-gpt-prototype/server.js
@@ -264,6 +264,17 @@ app.post("/api/campaigns/:id/resume", (req, res) => {
   res.json({ status: "resumed", campaignId: id });
 });
 
+// Apply refinement and rerun the current phase
+app.post("/api/campaigns/:id/refine", (req, res) => {
+  const { id } = req.params;
+  const { instructions } = req.body;
+  const refined = orchestrator.refineCampaign(id, instructions || "");
+  if (!refined) {
+    return res.status(400).json({ error: "Unable to refine campaign" });
+  }
+  res.json({ status: "refining", campaignId: id });
+});
+
 // Serve the frontend
 app.get("/", (req, res) => {
   res.sendFile(path.join(__dirname, "public", "index.html"));


### PR DESCRIPTION
## Summary
- implement `refineCampaign` in the orchestrator to rerun a phase with user updates
- expose `/api/campaigns/:id/refine` endpoint
- front-end shows a refinement textarea instead of restarting the campaign
- style refinement textarea
- document new refine behaviour

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6840b2e1a04483259cc3b6ddf7c74054