### PR TITLE
Fix PostCSS plugin import

### DIFF
--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,4 +1,4 @@
-import tailwindcss from '@tailwindcss/postcss';
+import tailwindcss from 'tailwindcss';
 import autoprefixer from 'autoprefixer';
 
 export default {


### PR DESCRIPTION
## Summary
- fix PostCSS config to use `tailwindcss` package

## Testing
- `npm --prefix hyatt-gpt-prototype run test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_b_6841d68377c48325a1dd1ca3fcdf5c4e