### PR TITLE
Improve polling error handling

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,30 +10,40 @@ function App() {
   const [deliverables, setDeliverables] = useState({});
   const [showModal, setShowModal] = useState(false);
   const [modalDeliverable, setModalDeliverable] = useState(null);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
     if (!campaignId) return;
-    const interval = setInterval(() => {
-      fetch(`/api/campaigns/${campaignId}`)
-        .then((res) => res.json())
-        .then((data) => {
-          if (data.conversation) {
-            setConversation(data.conversation);
-            const delivs = {};
-            data.conversation.forEach((msg) => {
-              if (msg.deliverable) {
-                const title = guessDeliverableTitle(msg.deliverable, msg.speaker);
-                const content = formatDeliverable(msg.deliverable);
-                delivs[msg.speaker] = { title, content };
-              }
-            });
-            setDeliverables(delivs);
-          }
-          if (data.status === 'completed') {
-            clearInterval(interval);
-          }
-        })
-        .catch(() => {});
+    let failureCount = 0;
+    const interval = setInterval(async () => {
+      try {
+        const res = await fetch(`/api/campaigns/${campaignId}`);
+        if (!res.ok) throw new Error('Network error');
+        const data = await res.json();
+        failureCount = 0;
+        setError(null);
+        if (data.conversation) {
+          setConversation(data.conversation);
+          const delivs = {};
+          data.conversation.forEach((msg) => {
+            if (msg.deliverable) {
+              const title = guessDeliverableTitle(msg.deliverable, msg.speaker);
+              const content = formatDeliverable(msg.deliverable);
+              delivs[msg.speaker] = { title, content };
+            }
+          });
+          setDeliverables(delivs);
+        }
+        if (data.status === 'completed') {
+          clearInterval(interval);
+        }
+      } catch {
+        failureCount += 1;
+        setError('Connection lost');
+        if (failureCount >= 3) {
+          clearInterval(interval);
+        }
+      }
     }, 3000);
     return () => clearInterval(interval);
   }, [campaignId]);
@@ -69,10 +79,15 @@ function App() {
       <h1 className="text-2xl font-bold mb-4">Hyatt GPT Agents System</h1>
       {!campaignId && <CampaignForm onCreate={startCampaign} />}
       {campaignId && (
-        <div className="mb-4 font-mono">Campaign ID: {campaignId}</div>
+        <div className="mb-4 font-mono">
+          Campaign ID: {campaignId}
+          {error && (
+            <span className="text-red-600 ml-2">{error}</span>
+          )}
+        </div>
       )}
       <div className="flex">
-        <ProgressPanel messages={conversation} />
+        <ProgressPanel messages={conversation} error={error} />
         <DeliverablesPanel
           deliverables={deliverables}
           onOpen={openModal}

--- a/frontend/src/components/ProgressPanel.jsx
+++ b/frontend/src/components/ProgressPanel.jsx
@@ -1,7 +1,8 @@
-function ProgressPanel({ messages }) {
+function ProgressPanel({ messages, error }) {
   return (
     <div className="w-1/2 mr-2 bg-white rounded shadow p-4 h-[500px] overflow-y-auto">
       <h2 className="font-semibold mb-2">Progress</h2>
+      {error && <p className="text-red-600 text-sm mb-2">{error}</p>}
       {messages.length === 0 && <p className="text-sm">No updates yet.</p>}
       {messages.map((m, idx) => (
         <div key={idx} className="mb-2 text-sm">


### PR DESCRIPTION
## Summary
- handle fetch failures and record network errors
- surface connection errors near the campaign ID and inside the progress panel

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6841d8e4f4b88325a141e17ab6e6ffae