### PR TITLE
Extract shared orchestration layout

### DIFF
--- a/frontend/src/components/orchestrations/HyattOrchestrationPage.tsx
+++ b/frontend/src/components/orchestrations/HyattOrchestrationPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import BaseOrchestrationPage from "./BaseOrchestrationPage";
+import SharedOrchestrationLayout from "./SharedOrchestrationLayout";
 import SidePanel from "../SidePanel";
 import CampaignProgress from "../CampaignProgress";
 import AgentCollaboration from "../AgentCollaboration";
@@ -457,69 +458,56 @@ const HyattOrchestrationPage: React.FC<HyattOrchestrationPageProps> = ({
             </div>
           )}
         </div>
-        <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
-          {/* Left Panel - Transcript (optional) */}
-          {isSidePanelOpen && (
-            <div className="lg:col-span-3">
-              <SidePanel
-                messages={conversation}
-                isOpen={isSidePanelOpen}
-                onClose={() => setIsSidePanelOpen(false)}
-              />
-            </div>
-          )}
-
-          {/* Central Panel - Progress & Actions */}
-          <div
-            className={`${
-              isSidePanelOpen ? "lg:col-span-5" : "lg:col-span-8"
-            } space-y-6`}
-          >
-            {!campaign ? (
-              <CampaignForm
-                onCreate={startCampaign}
-                onCancel={handleNewCampaign}
-                isLoading={isLoading}
-                selectedOrchestration={selectedOrchestration}
-                onNewCampaign={handleNewCampaign}
-                onLoadCampaign={handleSelectCampaign}
-                campaigns={campaigns}
-                dropdownOpen={dropdownOpen}
-                setDropdownOpen={setDropdownOpen}
-              />
-            ) : (
-              <>
-                <CampaignProgress
-                  campaign={campaign}
-                  onViewProgress={() => setIsSidePanelOpen(true)}
-                />
-
-                <AgentCollaboration
-                  messages={conversation}
-                  campaign={campaign}
-                  onResume={handleResume}
-                  onRefine={handleRefine}
-                  onViewDeliverable={handleViewPhaseDeliverable}
-                />
-
-                {/* ReviewPanel removed - controls now integrated into phase cards */}
-              </>
-            )}
-          </div>
-
-          {/* Right Panel - Deliverables */}
-          <div className="lg:col-span-4">
+        <SharedOrchestrationLayout
+          isSidePanelOpen={isSidePanelOpen}
+          sidePanel={
+            <SidePanel
+              messages={conversation}
+              isOpen={isSidePanelOpen}
+              onClose={() => setIsSidePanelOpen(false)}
+            />
+          }
+          rightPanel={
             <CampaignDeliverables
               deliverables={Object.values(deliverables)}
               onViewDetails={(id) => {
-                const deliverable = Object.values(deliverables).find(
-                  (d) => d.id === id
-                );
+                const deliverable = Object.values(deliverables).find((d) => d.id === id);
                 if (deliverable) handleViewDetails(deliverable);
               }}
             />
-          </div>
-        </div>
+          }
+        >
+          {!campaign ? (
+            <CampaignForm
+              onCreate={startCampaign}
+              onCancel={handleNewCampaign}
+              isLoading={isLoading}
+              selectedOrchestration={selectedOrchestration}
+              onNewCampaign={handleNewCampaign}
+              onLoadCampaign={handleSelectCampaign}
+              campaigns={campaigns}
+              dropdownOpen={dropdownOpen}
+              setDropdownOpen={setDropdownOpen}
+            />
+          ) : (
+            <>
+              <CampaignProgress
+                campaign={campaign}
+                onViewProgress={() => setIsSidePanelOpen(true)}
+              />
+
+              <AgentCollaboration
+                messages={conversation}
+                campaign={campaign}
+                onResume={handleResume}
+                onRefine={handleRefine}
+                onViewDeliverable={handleViewPhaseDeliverable}
+              />
+
+              {/* ReviewPanel removed - controls now integrated into phase cards */}
+            </>
+          )}
+        </SharedOrchestrationLayout>
       </div>
 
       <DeliverableModal

--- a/frontend/src/components/orchestrations/SharedOrchestrationLayout.tsx
+++ b/frontend/src/components/orchestrations/SharedOrchestrationLayout.tsx
@@ -1,0 +1,37 @@
+import React, { ReactNode } from "react";
+
+interface SharedOrchestrationLayoutProps {
+  /** Whether the left SidePanel is open */
+  isSidePanelOpen: boolean;
+  /** Optional SidePanel component */
+  sidePanel?: ReactNode;
+  /** Main content rendered in the center column */
+  children: ReactNode;
+  /** Right column content such as CampaignDeliverables */
+  rightPanel: ReactNode;
+}
+
+/**
+ * Provides the standard three‑column grid used across orchestration pages.
+ * Preserves Hyatt’s spacing and responsive behavior.
+ */
+const SharedOrchestrationLayout: React.FC<SharedOrchestrationLayoutProps> = ({
+  isSidePanelOpen,
+  sidePanel,
+  children,
+  rightPanel,
+}) => {
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
+      {isSidePanelOpen && <div className="lg:col-span-3">{sidePanel}</div>}
+      <div
+        className={`${isSidePanelOpen ? "lg:col-span-5" : "lg:col-span-8"} space-y-6`}
+      >
+        {children}
+      </div>
+      <div className="lg:col-span-4">{rightPanel}</div>
+    </div>
+  );
+};
+
+export default SharedOrchestrationLayout;

--- a/orchestration-feature-parity-checklist.md
+++ b/orchestration-feature-parity-checklist.md
@@ -7,6 +7,10 @@ This checklist inventories the existing Hyatt orchestration UI and backend capab
   - **Left:** Transcript SidePanel with message log and agent icons
   - **Center:** Campaign progress, forms and collaboration controls
   - **Right:** Deliverable list with cards and status badges
+  - **Classes:** `grid grid-cols-1 lg:grid-cols-12 gap-6` with
+    `lg:col-span-3` for the SidePanel,
+    `lg:col-span-5` (or `lg:col-span-8` when closed) for the center column,
+    and `lg:col-span-4` for deliverables. Wrapped in `container pt-6 pb-8`.
 - Global navigation bar with links to **Orchestrations**, **Agents**, and **Workflows**
 - Breadcrumb at top of Hyatt orchestration page
 - HITL (Human‑in‑the‑loop) toggle displayed in page header


### PR DESCRIPTION
## Summary
- create `SharedOrchestrationLayout` component providing Hyatt's three-column grid
- refactor `HyattOrchestrationPage` to use the shared layout
- document layout classes in `orchestration-feature-parity-checklist.md`

## Testing
- `npm install` in `frontend`
- `npx eslint .` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_687a627d15fc8325a92f555f24283c44