### PR TITLE
Add shared UI component library

### DIFF
--- a/frontend/src/components/shared/SharedActionButtons.tsx
+++ b/frontend/src/components/shared/SharedActionButtons.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+/**
+ * Resume/Refine action buttons shown during manual review.
+ *
+ * Tailwind classes:
+ * - Buttons use `px-6 py-2` with green and blue background colors
+ * - Wrapped in `flex justify-center space-x-4`
+ */
+export interface SharedActionButtonsProps {
+  onResume: () => void;
+  onRefine: () => void;
+}
+
+const SharedActionButtons: React.FC<SharedActionButtonsProps> = ({ onResume, onRefine }) => (
+  <div className="flex justify-center space-x-4">
+    <button className="px-6 py-2 bg-green-500 hover:bg-green-600 text-white rounded-md transition-colors font-medium" onClick={onResume}>
+      ✅ Resume Campaign
+    </button>
+    <button className="px-6 py-2 bg-blue-500 hover:bg-blue-600 text-white rounded-md transition-colors font-medium" onClick={onRefine}>
+      ✏️ Refine & Retry
+    </button>
+  </div>
+);
+
+export default SharedActionButtons;

--- a/frontend/src/components/shared/SharedBreadcrumbs.tsx
+++ b/frontend/src/components/shared/SharedBreadcrumbs.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+/**
+ * Standard breadcrumbs used across orchestrations.
+ *
+ * Tailwind classes:
+ * - `flex items-center space-x-2 text-sm text-gray-600` – breadcrumb list
+ * - `text-green-600 hover:text-green-700` – back link
+ * - `text-gray-800 font-medium` – current page name
+ */
+export interface SharedBreadcrumbsProps {
+  onBack: () => void;
+  current: string;
+}
+
+const SharedBreadcrumbs: React.FC<SharedBreadcrumbsProps> = ({ onBack, current }) => (
+  <nav className="flex items-center space-x-2 text-sm text-gray-600">
+    <button onClick={onBack} className="text-green-600 hover:text-green-700 transition-colors">
+      Orchestrations
+    </button>
+    <span>›</span>
+    <span className="text-gray-800 font-medium">{current}</span>
+  </nav>
+);
+
+export default SharedBreadcrumbs;

--- a/frontend/src/components/shared/SharedCampaignForm.tsx
+++ b/frontend/src/components/shared/SharedCampaignForm.tsx
@@ -1,0 +1,146 @@
+import React, { useState } from 'react';
+
+/**
+ * SharedCampaignForm replicates Hyatt's campaign creation form.
+ *
+ * Tailwind classes:
+ * - `bg-white rounded-lg shadow-md p-6` – card container styling
+ * - `text-2xl font-bold text-slate-800 mb-4` – heading
+ * - `mb-4 p-3 bg-blue-50 border border-blue-200 rounded-md` – selected orchestration banner
+ * - `block text-sm font-medium text-slate-600 mb-2` – label styling
+ * - `w-full h-32 p-3 border border-slate-300 rounded-md focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition` – textarea
+ * - Buttons use utility classes like `px-4 py-2`, `bg-green-600`, `hover:bg-green-700`, etc.
+ */
+export interface SharedCampaignFormProps {
+  onCreate: (brief: string) => void;
+  isLoading: boolean;
+  onCancel: () => void;
+  selectedOrchestration?: string | null;
+  onNewCampaign: () => void;
+  onLoadCampaign: (campaignId: string) => void;
+  campaigns: any[];
+  dropdownOpen: boolean;
+  setDropdownOpen: (open: boolean) => void;
+}
+
+const SharedCampaignForm: React.FC<SharedCampaignFormProps> = ({
+  onCreate,
+  isLoading,
+  onCancel,
+  selectedOrchestration,
+  onNewCampaign,
+  onLoadCampaign,
+  campaigns,
+  dropdownOpen,
+  setDropdownOpen,
+}) => {
+  const [brief, setBrief] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (brief.trim()) {
+      onCreate(brief.trim());
+    }
+  };
+
+  return (
+    <div className="bg-white rounded-lg shadow-md p-6">
+      <h2 className="text-2xl font-bold text-slate-800 mb-4">Create New Campaign</h2>
+      {selectedOrchestration && (
+        <div className="mb-4 p-3 bg-blue-50 border border-blue-200 rounded-md">
+          <p className="text-sm text-blue-800">
+            <strong>Selected Orchestration:</strong>{' '}
+            {selectedOrchestration === 'hive' ? 'Hive Orchestrator' : 'Hyatt Orchestrator'}
+          </p>
+        </div>
+      )}
+      <form onSubmit={handleSubmit}>
+        <div className="mb-4">
+          <label htmlFor="campaignBrief" className="block text-sm font-medium text-slate-600 mb-2">
+            Campaign Brief
+          </label>
+          <textarea
+            id="campaignBrief"
+            value={brief}
+            onChange={(e) => setBrief(e.target.value)}
+            className="w-full h-32 p-3 border border-slate-300 rounded-md focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition"
+            placeholder="We're launching a new property next quarter..."
+            disabled={isLoading}
+          />
+        </div>
+        <div className="flex justify-between items-center">
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={onNewCampaign}
+              className="px-4 py-2 bg-green-600 text-white font-medium rounded hover:bg-green-700 transition-colors"
+            >
+              New Campaign
+            </button>
+            <div className="relative">
+              <button
+                type="button"
+                className="px-4 py-2 bg-white text-gray-700 font-medium rounded border border-gray-300 hover:border-gray-400 flex items-center transition-colors"
+                onClick={() => setDropdownOpen(!dropdownOpen)}
+              >
+                <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2H5a2 2 0 00-2-2z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 5a2 2 0 012-2h4a2 2 0 012 2v2H8V5z" />
+                </svg>
+                Load Campaign
+                <svg className="w-4 h-4 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
+              {dropdownOpen && (
+                <div className="absolute left-0 mt-1 w-80 bg-white rounded border border-gray-200 shadow-sm z-50">
+                  <div className="p-3 border-b border-gray-100">
+                    <div className="text-gray-900 font-medium text-sm">All Campaigns ({campaigns.length})</div>
+                  </div>
+                  <div className="max-h-64 overflow-y-auto">
+                    {campaigns.length > 0 ? (
+                      campaigns.map((campaign) => (
+                        <button
+                          key={campaign.id}
+                          onClick={() => {
+                            onLoadCampaign(campaign.id);
+                            setDropdownOpen(false);
+                          }}
+                          className="w-full text-left p-3 hover:bg-gray-50 border-b border-gray-100 last:border-b-0"
+                        >
+                          <div className="text-gray-900 text-sm">{campaign.brief.substring(0, 60)}...</div>
+                          <div className="text-xs text-gray-500 mt-1">Status: {campaign.status}</div>
+                        </button>
+                      ))
+                    ) : (
+                      <div className="p-4 text-center text-gray-500 text-sm">No campaigns available</div>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+          <div className="flex gap-3">
+            <button
+              type="submit"
+              disabled={isLoading || !brief.trim()}
+              className="px-4 py-2 bg-green-600 text-white font-medium rounded hover:bg-green-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+            >
+              {isLoading ? 'Creating...' : 'Create Campaign'}
+            </button>
+            <button
+              type="button"
+              onClick={onCancel}
+              className="px-4 py-2 bg-gray-200 text-gray-800 font-medium rounded hover:bg-gray-300 transition-colors"
+              disabled={isLoading}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default SharedCampaignForm;

--- a/frontend/src/components/shared/SharedDeliverableCard.tsx
+++ b/frontend/src/components/shared/SharedDeliverableCard.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { Deliverable } from '../../types';
+import { Eye, Download } from 'lucide-react';
+import '../deliverableStyles.css';
+
+/**
+ * Card representation for a single deliverable.
+ *
+ * Tailwind/custom classes:
+ * - `.deliverable-card` – flex card container (see deliverableStyles.css)
+ * - `.deliverable-icon-btn` – icon action buttons
+ * - `.deliverable-status.{state}` – colored status badge
+ */
+export interface SharedDeliverableCardProps {
+  deliverable: Deliverable;
+  onViewDetails: (id: string) => void;
+}
+
+const SharedDeliverableCard: React.FC<SharedDeliverableCardProps> = ({ deliverable, onViewDetails }) => {
+  const getAgentIcon = (agent: string) => {
+    if (agent?.includes('Research')) return '🔍';
+    if (agent?.includes('Strategic')) return '🎯';
+    if (agent?.includes('Trending')) return '📈';
+    if (agent?.includes('Story')) return '📝';
+    if (agent?.includes('Visual')) return '🎨';
+    if (agent?.includes('PR')) return '📢';
+    return '👨‍💼';
+  };
+
+  const handleDownload = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    const content = typeof deliverable.content === 'string' ? deliverable.content : JSON.stringify(deliverable.content, null, 2);
+    const blob = new Blob([content], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${deliverable.title.replace(/\s+/g, '_')}.txt`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="deliverable-card flex flex-col gap-2 cursor-pointer hover:shadow-md transition-shadow" onClick={() => onViewDetails(deliverable.id)}>
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <span className="deliverable-icon text-2xl">📋</span>
+            <h3 className="deliverable-title-text text-lg font-semibold truncate" title={deliverable.title}>
+              {deliverable.title}
+            </h3>
+          </div>
+          <div className="flex items-center gap-2 text-sm text-gray-500">
+            <span className="deliverable-agent-icon">{getAgentIcon(deliverable.agent)}</span>
+            <span className="truncate" title={deliverable.agent}>
+              {deliverable.agent || 'AI Agent'}
+            </span>
+          </div>
+        </div>
+        <div className="flex flex-col items-end gap-2 ml-2">
+          <span className={`deliverable-status ${deliverable.status} text-xs mb-1`}>
+            {deliverable.status === 'ready' ? 'Ready' : deliverable.status === 'reviewed' ? 'Reviewed' : 'Pending'}
+          </span>
+          <div className="flex gap-2 mt-1">
+            <button className="deliverable-icon-btn" onClick={handleDownload} title="Download" tabIndex={0} aria-label="Download Deliverable">
+              <Download size={18} />
+            </button>
+            <button
+              className="deliverable-icon-btn"
+              onClick={(e) => {
+                e.stopPropagation();
+                onViewDetails(deliverable.id);
+              }}
+              title="View Details"
+              tabIndex={0}
+              aria-label="View Details"
+            >
+              <Eye size={18} />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SharedDeliverableCard;

--- a/frontend/src/components/shared/SharedDeliverablePanel.tsx
+++ b/frontend/src/components/shared/SharedDeliverablePanel.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Deliverable } from '../../types';
+import SharedDeliverableCard from './SharedDeliverableCard';
+import { FileText } from 'lucide-react';
+import '../deliverableStyles.css';
+
+/**
+ * Panel listing deliverable cards in a vertical list.
+ *
+ * Tailwind/custom classes: see deliverableStyles.css for `.deliverable-card` etc.
+ */
+export interface SharedDeliverablePanelProps {
+  deliverables: Deliverable[];
+  onViewDetails: (id: string) => void;
+}
+
+const SharedDeliverablePanel: React.FC<SharedDeliverablePanelProps> = ({ deliverables, onViewDetails }) => (
+  <div className="deliverable-card">
+    <div className="deliverable-header">
+      <div className="deliverable-title">
+        <span className="deliverable-icon">
+          <FileText size={20} />
+        </span>
+        <h2 className="deliverable-title-text">Campaign Deliverables</h2>
+      </div>
+      <div className="deliverable-status ready">{deliverables.length} Available</div>
+    </div>
+    {deliverables.length === 0 ? (
+      <div className="text-center py-8 text-gray-500">
+        <FileText size={48} className="mx-auto mb-4 text-gray-300" />
+        <p>No deliverables available yet.</p>
+        <p className="text-sm">Start a campaign to see deliverables here.</p>
+      </div>
+    ) : (
+      <div className="space-y-4">
+        {deliverables.map((d) => (
+          <SharedDeliverableCard key={d.id} deliverable={d} onViewDetails={onViewDetails} />
+        ))}
+      </div>
+    )}
+  </div>
+);
+
+export default SharedDeliverablePanel;

--- a/frontend/src/components/shared/SharedHitlToggle.tsx
+++ b/frontend/src/components/shared/SharedHitlToggle.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+/**
+ * Toggle switch used to enable/disable HITL review.
+ *
+ * Tailwind classes:
+ * - container `flex items-center gap-2`
+ * - switch uses `relative inline-flex h-6 w-12 items-center rounded-full` with conditional bg color
+ * - knob uses `inline-block h-4 w-4 transform rounded-full bg-white`
+ */
+export interface SharedHitlToggleProps {
+  enabled: boolean;
+  onToggle: () => void;
+}
+
+const SharedHitlToggle: React.FC<SharedHitlToggleProps> = ({ enabled, onToggle }) => (
+  <div className="flex items-center gap-2">
+    <span className="text-sm text-gray-600">HITL Review</span>
+    <button onClick={onToggle} className={`relative inline-flex h-6 w-12 items-center rounded-full ${enabled ? 'bg-green-600' : 'bg-gray-300'}`}>
+      <span className={`inline-block h-4 w-4 transform rounded-full bg-white ${enabled ? 'translate-x-7' : 'translate-x-1'}`} />
+      <span className={`absolute text-xs font-medium ${enabled ? 'text-white left-1' : 'text-gray-600 right-1'}`}>{enabled ? 'ON' : 'OFF'}</span>
+    </button>
+  </div>
+);
+
+export default SharedHitlToggle;

--- a/frontend/src/components/shared/SharedModal.tsx
+++ b/frontend/src/components/shared/SharedModal.tsx
@@ -1,0 +1,28 @@
+import React, { ReactNode } from 'react';
+
+/**
+ * Basic modal wrapper used to standardize overlays.
+ *
+ * Tailwind/custom classes:
+ * - overlay: `fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4`
+ * - content: `bg-white rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] overflow-y-auto`
+ */
+export interface SharedModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  children: ReactNode;
+  maxWidthClass?: string; // allow overriding width
+}
+
+const SharedModal: React.FC<SharedModalProps> = ({ isOpen, onClose, children, maxWidthClass = 'max-w-2xl' }) => {
+  if (!isOpen) return null;
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4" onClick={onClose}>
+      <div className={`bg-white rounded-lg shadow-xl w-full ${maxWidthClass} max-h-[90vh] overflow-y-auto`} onClick={(e) => e.stopPropagation()}>
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default SharedModal;

--- a/frontend/src/components/shared/SharedProgressPanel.tsx
+++ b/frontend/src/components/shared/SharedProgressPanel.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Campaign } from '../../types';
+import { RefreshCw } from 'lucide-react';
+
+/**
+ * Displays basic campaign status with a call to view detailed progress.
+ *
+ * Tailwind classes used:
+ * - `bg-slate-700 rounded-lg shadow-md p-6` – container
+ * - `text-2xl font-bold text-white mb-4` – heading
+ * - `text-sm text-slate-300 mb-1` – labels
+ * - status badge colors (`bg-blue-100`, `bg-green-100`, etc.)
+ * - button `px-4 py-2 bg-indigo-500 hover:bg-indigo-600 text-white rounded-md`
+ */
+export interface SharedProgressPanelProps {
+  campaign: Campaign;
+  onViewProgress: () => void;
+}
+
+const SharedProgressPanel: React.FC<SharedProgressPanelProps> = ({ campaign, onViewProgress }) => {
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case 'active':
+        return 'bg-blue-100 text-blue-800';
+      case 'completed':
+        return 'bg-green-100 text-green-800';
+      case 'failed':
+        return 'bg-red-100 text-red-800';
+      default:
+        return 'bg-slate-100 text-slate-800';
+    }
+  };
+
+  return (
+    <div className="bg-slate-700 rounded-lg shadow-md p-6">
+      <h2 className="text-2xl font-bold text-white mb-4">Campaign Progress</h2>
+      <div className="mb-4">
+        <div className="text-sm text-slate-300 mb-1">Campaign ID: {campaign.id}</div>
+        <div className="flex items-center">
+          <span className={`inline-block px-2 py-1 rounded-full text-xs font-medium mr-2 ${getStatusColor(campaign.status)}`}>{campaign.status}</span>
+        </div>
+      </div>
+      <button
+        className="flex items-center justify-center px-4 py-2 bg-indigo-500 hover:bg-indigo-600 text-white rounded-md transition-colors text-sm"
+        onClick={onViewProgress}
+      >
+        <RefreshCw size={16} className="mr-2" />
+        View Detailed Progress
+      </button>
+    </div>
+  );
+};
+
+export default SharedProgressPanel;

--- a/frontend/src/components/shared/index.ts
+++ b/frontend/src/components/shared/index.ts
@@ -1,0 +1,8 @@
+export { default as SharedCampaignForm } from './SharedCampaignForm';
+export { default as SharedProgressPanel } from './SharedProgressPanel';
+export { default as SharedDeliverablePanel } from './SharedDeliverablePanel';
+export { default as SharedDeliverableCard } from './SharedDeliverableCard';
+export { default as SharedBreadcrumbs } from './SharedBreadcrumbs';
+export { default as SharedHitlToggle } from './SharedHitlToggle';
+export { default as SharedActionButtons } from './SharedActionButtons';
+export { default as SharedModal } from './SharedModal';

--- a/frontend/src/docs/SHARED_COMPONENTS_STYLES.md
+++ b/frontend/src/docs/SHARED_COMPONENTS_STYLES.md
@@ -1,0 +1,41 @@
+# Shared Components Tailwind Reference
+
+This document lists the main Tailwind utility classes and custom CSS selectors used by the extracted shared UI components. Use it as a quick reference when creating new orchestrations.
+
+## SharedCampaignForm
+- `bg-white rounded-lg shadow-md p-6` – form card container
+- `text-2xl font-bold text-slate-800 mb-4` – heading style
+- `mb-4 p-3 bg-blue-50 border border-blue-200 rounded-md` – selected orchestration banner
+- `block text-sm font-medium text-slate-600 mb-2` – form labels
+- `w-full h-32 p-3 border border-slate-300 rounded-md focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition` – textarea input
+- Buttons use `px-4 py-2` plus background colors such as `bg-green-600` and `bg-gray-200`
+
+## SharedProgressPanel
+- `bg-slate-700 rounded-lg shadow-md p-6` – card container
+- `text-2xl font-bold text-white mb-4` – heading
+- Status badges use background utilities like `bg-blue-100`, `bg-green-100`, etc.
+- View progress button uses `bg-indigo-500 hover:bg-indigo-600 text-white rounded-md`
+
+## SharedDeliverablePanel and Card
+The panel and card rely on styles defined in `deliverableStyles.css`:
+- `.deliverable-card`, `.deliverable-header`, `.deliverable-title-text`
+- `.deliverable-status.ready`, `.deliverable-status.reviewed`, `.deliverable-status.pending`
+- Action buttons use `.deliverable-icon-btn`
+
+## SharedBreadcrumbs
+- `flex items-center space-x-2 text-sm text-gray-600` – wrapper
+- `text-green-600 hover:text-green-700` – back link
+- `text-gray-800 font-medium` – current page
+
+## SharedHitlToggle
+- Wrapper `flex items-center gap-2`
+- Toggle switch `relative inline-flex h-6 w-12 items-center rounded-full`
+- Toggle knob `inline-block h-4 w-4 transform rounded-full bg-white`
+
+## SharedActionButtons
+- Wrapper `flex justify-center space-x-4`
+- Buttons: `px-6 py-2` with `bg-green-500` or `bg-blue-500`
+
+## SharedModal
+- Overlay `fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4`
+- Content container `bg-white rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] overflow-y-auto`


### PR DESCRIPTION
## Summary
- build `shared` component folder for reuse across orchestrations
- document Tailwind classes for these components

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687a6a08fab48325a952b6ff041723c4