### PR TITLE
Centralize style tokens

### DIFF
--- a/frontend/src/components/deliverableStyles.css
+++ b/frontend/src/components/deliverableStyles.css
@@ -1,7 +1,9 @@
+@import '../styles/design-tokens.css';
+
 /* ===== DELIVERABLE CONTENT STYLING ===== */
 
 .deliverable-content-wrapper {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-family: var(--font-sans);
   line-height: 1.6;
   color: #2c3e50;
   background: #ffffff;

--- a/frontend/src/docs/SHARED_COMPONENTS_STYLES.md
+++ b/frontend/src/docs/SHARED_COMPONENTS_STYLES.md
@@ -2,6 +2,8 @@
 
 This document lists the main Tailwind utility classes and custom CSS selectors used by the extracted shared UI components. Use it as a quick reference when creating new orchestrations.
 
+Design tokens are defined in `../styles/design-tokens.css`. For a complete list of Tailwind classes found in the project, see `../../used_classes.txt`.
+
 ## SharedCampaignForm
 - `bg-white rounded-lg shadow-md p-6` – form card container
 - `text-2xl font-bold text-slate-800 mb-4` – heading style

--- a/frontend/src/docs/STYLE_TOKENS_REFERENCE.md
+++ b/frontend/src/docs/STYLE_TOKENS_REFERENCE.md
@@ -1,0 +1,20 @@
+# Style Tokens Reference
+
+Design tokens live in `src/styles/design-tokens.css` to keep colors, spacing and typography consistent.
+
+## Color Tokens
+- `--color-primary` – primary green used for buttons and highlights
+- `--color-primary-hover` – darker primary green for hover states
+- `--color-secondary` – light gray page background
+- `--color-border` – neutral border color
+- `--color-text-primary` – default text color
+- `--color-text-secondary` – muted text color
+
+## Typography Tokens
+- `--font-sans` – main sans-serif font stack
+- `--font-base-size` – base font size
+
+## Spacing Tokens
+- `--spacing-container` – horizontal padding for the main container
+
+Use these tokens in custom CSS. Tailwind utilities are documented in `SHARED_COMPONENTS_STYLES.md` and the full list of classes generated in `../../used_classes.txt`.

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,6 +2,8 @@
 @tailwind components;
 @tailwind utilities;
 
+@import "./styles/design-tokens.css";
+
 /* ===== SIMPLIFIED DESIGN SYSTEM ===== */
 /* Only the classes you actually use! */
 
@@ -13,11 +15,11 @@
 }
 
 body {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background-color: #f8f9fa;
-  color: #212529;
+  font-family: var(--font-sans);
+  background-color: var(--color-secondary);
+  color: var(--color-text-primary);
   line-height: 1.6;
-  font-size: 16px;
+  font-size: var(--font-base-size);
 }
 
 #root {
@@ -33,8 +35,8 @@ body {
   max-width: 1800px;
   width: 100%;
   margin: 0 auto;
-  padding-left: 2rem;
-  padding-right: 2rem;
+  padding-left: var(--spacing-container);
+  padding-right: var(--spacing-container);
 }
 
 /* Buttons */
@@ -52,19 +54,20 @@ body {
   text-decoration: none;
 }
 
+
 .btn-primary {
-  background: #4CAF50;
+  background: var(--color-primary);
   color: white;
 }
 
 .btn-primary:hover {
-  background: #45a049;
+  background: var(--color-primary-hover);
 }
 
 .btn-secondary {
   background: white;
-  color: #212529;
-  border: 1px solid #dee2e6;
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
 }
 
 .btn-secondary:hover {
@@ -74,7 +77,7 @@ body {
 /* Cards */
 .card {
   background: white;
-  border: 1px solid #e9ecef;
+  border: 1px solid var(--color-border);
   border-radius: 0.75rem;
   padding: 1.5rem;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
@@ -82,7 +85,7 @@ body {
 }
 
 .card:hover {
-  border-color: #4CAF50;
+  border-color: var(--color-primary);
   transform: translateY(-2px);
   box-shadow: 0 4px 16px rgba(76, 175, 80, 0.1);
 }
@@ -90,7 +93,7 @@ body {
 /* Compact Cards */
 .card-compact {
   background: white;
-  border: 1px solid #e9ecef;
+  border: 1px solid var(--color-border);
   border-radius: 0.5rem;
   padding: 1rem;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
@@ -98,7 +101,7 @@ body {
 }
 
 .card-compact:hover {
-  border-color: #4CAF50;
+  border-color: var(--color-primary);
   transform: translateY(-1px);
   box-shadow: 0 2px 8px rgba(76, 175, 80, 0.1);
 }
@@ -147,17 +150,17 @@ body {
 }
 
 /* Colors */
-.text-primary { color: #212529; }
-.text-secondary { color: #6c757d; }
+.text-primary { color: var(--color-text-primary); }
+.text-secondary { color: var(--color-text-secondary); }
 .text-success { color: #28a745; }
-.bg-secondary { background-color: #f8f9fa; }
+.bg-secondary { background-color: var(--color-secondary); }
 .bg-success { background-color: #28a745; }
 
 /* Special component */
 .agent-title {
   font-size: 1.25rem;
   font-weight: 600;
-  color: #212529;
+  color: var(--color-text-primary);
   margin-bottom: 0.5rem;
 }
 

--- a/frontend/src/styles/design-tokens.css
+++ b/frontend/src/styles/design-tokens.css
@@ -1,0 +1,16 @@
+:root {
+  /* Colors */
+  --color-primary: #4CAF50;
+  --color-primary-hover: #45a049;
+  --color-secondary: #f8f9fa;
+  --color-border: #e9ecef;
+  --color-text-primary: #212529;
+  --color-text-secondary: #6c757d;
+
+  /* Typography */
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-base-size: 16px;
+
+  /* Spacing */
+  --spacing-container: 2rem;
+}


### PR DESCRIPTION
## Summary
- create `design-tokens.css` with color, spacing and typography variables
- import the token file and use variables in `index.css`
- hook deliverable styles into the token system
- document tokens and reference used Tailwind classes

## Testing
- `npm install --prefix frontend`
- `npm test --prefix frontend` *(tests skipped)*

------
https://chatgpt.com/codex/tasks/task_b_687a752928588325831970ebd37523e7