### PR TITLE
Migrate nav and core pages to tokens

### DIFF
--- a/frontend/src/components/GlobalNav.tsx
+++ b/frontend/src/components/GlobalNav.tsx
@@ -15,14 +15,14 @@ const GlobalNav: React.FC<GlobalNavProps> = ({
   onNavigateToOrchestrations,
 }) => {
   return (
-    <nav className="bg-white border-b border-gray-200">
+    <nav className="bg-white border-b border-border">
       <div className="container">
         <div className="flex items-center justify-between h-[73px]">
           {/* Brand */}
           <div className="flex items-center">
             <div className="text-xl font-bold">
-              <span className="text-green-600">ZENO</span>
-              <span className="text-gray-800"> AI HIVE</span>
+              <span className="text-success">ZENO</span>
+              <span className="text-text-primary"> AI HIVE</span>
             </div>
           </div>
 
@@ -32,8 +32,8 @@ const GlobalNav: React.FC<GlobalNavProps> = ({
               <button
                 className={`px-4 py-2 text-sm font-medium rounded ${
                   currentView === "orchestrations"
-                    ? "bg-green-600 text-white"
-                    : "text-gray-600 hover:text-gray-900 hover:bg-gray-100"
+                    ? "bg-success text-white"
+                    : "text-text-secondary hover:text-text-primary hover:bg-secondary"
                 }`}
                 onClick={onNavigateToOrchestrations}
               >
@@ -43,8 +43,8 @@ const GlobalNav: React.FC<GlobalNavProps> = ({
               <button
                 className={`px-4 py-2 text-sm font-medium rounded flex items-center ${
                   currentView === "agents"
-                    ? "bg-green-600 text-white"
-                    : "text-gray-600 hover:text-gray-900 hover:bg-gray-100"
+                    ? "bg-success text-white"
+                    : "text-text-secondary hover:text-text-primary hover:bg-secondary"
                 }`}
                 onClick={onNavigateToAgents}
               >
@@ -54,8 +54,8 @@ const GlobalNav: React.FC<GlobalNavProps> = ({
               <button
                 className={`px-4 py-2 text-sm font-medium rounded ${
                   currentView === "workflows"
-                    ? "bg-green-600 text-white"
-                    : "text-gray-600 hover:text-gray-900 hover:bg-gray-100"
+                    ? "bg-success text-white"
+                    : "text-text-secondary hover:text-text-primary hover:bg-secondary"
                 }`}
                 onClick={onNavigateToWorkflows}
               >

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -142,7 +142,7 @@ const Header: React.FC<HeaderProps> = ({
             <span className="mr-2 text-slate-300">HITL Review</span>
             <div
               className={`relative w-12 h-6 rounded-full transition-colors duration-200 ease-in-out ${
-                hitlReview ? "bg-green-500" : "bg-slate-500"
+                hitlReview ? "bg-success" : "bg-secondary"
               }`}
               onClick={onToggleHitl}
             >

--- a/frontend/src/components/OrchestrationsPage.tsx
+++ b/frontend/src/components/OrchestrationsPage.tsx
@@ -155,8 +155,8 @@ const OrchestrationsPage: React.FC<OrchestrationsPageProps> = ({
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-green-500 mx-auto mb-4"></div>
-          <p className="text-gray-600">Loading orchestrations...</p>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-success mx-auto mb-4"></div>
+          <p className="text-text-secondary">Loading orchestrations...</p>
         </div>
       </div>
     );
@@ -166,24 +166,24 @@ const OrchestrationsPage: React.FC<OrchestrationsPageProps> = ({
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">
-          <p className="text-red-600 mb-4">
+          <p className="text-error mb-4">
             Error loading orchestrations: {error}
           </p>
-          <p className="text-gray-600">Using demo orchestrations</p>
+          <p className="text-text-secondary">Using demo orchestrations</p>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-secondary">
       <div className="container mx-auto py-8 px-4">
         {/* Header */}
         <div className="text-center mb-8">
-          <h1 className="text-2xl font-bold text-gray-900 mb-3">
+          <h1 className="text-2xl font-bold text-text-primary mb-3">
             Choose Your Orchestration
           </h1>
-          <p className="text-base text-gray-600 max-w-2xl mx-auto">
+          <p className="text-base text-text-secondary max-w-2xl mx-auto">
             Select the orchestration framework that best fits your campaign
             needs. Each orchestrator has different capabilities and execution
             patterns.
@@ -195,25 +195,25 @@ const OrchestrationsPage: React.FC<OrchestrationsPageProps> = ({
           {orchestrations.map((orchestration) => (
             <div
               key={orchestration.id}
-              className="bg-white rounded-xl shadow-lg hover:shadow-xl transition-all duration-300 border border-gray-200 overflow-hidden"
+              className="bg-white rounded-xl shadow-lg hover:shadow-xl transition-all duration-300 border border-border overflow-hidden"
             >
               {/* Header */}
-              <div className="p-4 border-b border-gray-100">
+              <div className="p-4 border-b border-border">
                 <div className="flex items-center justify-between mb-3">
-                  <h2 className="text-xl font-bold text-gray-900">
+                  <h2 className="text-xl font-bold text-text-primary">
                     {orchestration.name}
                   </h2>
                   <div
                     className={`px-2 py-1 rounded-full text-xs font-medium ${
                       orchestration.enabled
-                        ? "bg-green-100 text-green-800"
+                        ? "bg-success-light text-success"
                         : "bg-red-100 text-red-800"
                     }`}
                   >
                     {orchestration.enabled ? "Active" : "Inactive"}
                   </div>
                 </div>
-                <p className="text-sm text-gray-600 leading-relaxed">
+                <p className="text-sm text-text-secondary leading-relaxed">
                   {orchestration.description}
                 </p>
               </div>
@@ -221,17 +221,17 @@ const OrchestrationsPage: React.FC<OrchestrationsPageProps> = ({
               {/* Features */}
               <div className="p-4">
                 <div className="grid grid-cols-2 gap-3 mb-4">
-                  <div className="text-center p-2 bg-gray-50 rounded-lg">
-                    <div className="text-lg font-bold text-blue-600">
+                  <div className="text-center p-2 bg-secondary rounded-lg">
+                    <div className="text-lg font-bold text-primary">
                       {orchestration.config.maxConcurrentWorkflows}
                     </div>
-                    <div className="text-xs text-gray-600">Max Workflows</div>
+                    <div className="text-xs text-text-secondary">Max Workflows</div>
                   </div>
-                  <div className="text-center p-2 bg-gray-50 rounded-lg">
-                    <div className="text-lg font-bold text-green-600">
+                  <div className="text-center p-2 bg-secondary rounded-lg">
+                    <div className="text-lg font-bold text-success">
                       {orchestration.agents.length}
                     </div>
-                    <div className="text-xs text-gray-600">Agents</div>
+                    <div className="text-xs text-text-secondary">Agents</div>
                   </div>
                 </div>
 
@@ -242,8 +242,8 @@ const OrchestrationsPage: React.FC<OrchestrationsPageProps> = ({
                       <span className="w-2 h-2 bg-purple-500 rounded-full mr-2"></span>
                       Reactive Framework
                     </div>
-                    <div className="flex items-center text-sm text-blue-600">
-                      <span className="w-2 h-2 bg-blue-500 rounded-full mr-2"></span>
+                    <div className="flex items-center text-sm text-primary">
+                      <span className="w-2 h-2 bg-primary rounded-full mr-2"></span>
                       Parallel Execution
                     </div>
                   </div>
@@ -251,20 +251,20 @@ const OrchestrationsPage: React.FC<OrchestrationsPageProps> = ({
 
                 {/* Agents */}
                 <div className="mb-4">
-                  <h4 className="font-semibold text-gray-900 mb-2 text-sm">
+                  <h4 className="font-semibold text-text-primary mb-2 text-sm">
                     Available Agents
                   </h4>
                   <div className="flex flex-wrap gap-2">
                     {orchestration.agents.slice(0, 4).map((agent) => (
                       <span
                         key={agent}
-                        className="px-2 py-1 bg-blue-100 text-blue-800 text-xs rounded-full"
+                        className="px-2 py-1 bg-primary-light text-primary text-xs rounded-full"
                       >
                         {agent.replace("_", " ")}
                       </span>
                     ))}
                     {orchestration.agents.length > 4 && (
-                      <span className="px-2 py-1 bg-gray-100 text-gray-600 text-xs rounded-full">
+                      <span className="px-2 py-1 bg-secondary text-text-secondary text-xs rounded-full">
                         +{orchestration.agents.length - 4} more
                       </span>
                     )}
@@ -277,8 +277,8 @@ const OrchestrationsPage: React.FC<OrchestrationsPageProps> = ({
                   disabled={!orchestration.enabled}
                   className={`w-full py-2 px-4 rounded-lg font-semibold text-sm transition-all duration-200 ${
                     orchestration.enabled
-                      ? "bg-green-600 hover:bg-green-700 text-white shadow-lg hover:shadow-xl"
-                      : "bg-gray-300 text-gray-500 cursor-not-allowed"
+                      ? "bg-success hover:bg-success-hover text-white shadow-lg hover:shadow-xl"
+                      : "bg-secondary text-text-muted cursor-not-allowed"
                   }`}
                 >
                   {orchestration.enabled
@@ -292,11 +292,11 @@ const OrchestrationsPage: React.FC<OrchestrationsPageProps> = ({
 
         {/* Info Section */}
         <div className="mt-12 text-center">
-          <div className="bg-blue-50 border border-blue-200 rounded-lg p-6 max-w-4xl mx-auto">
-            <h3 className="text-lg font-semibold text-blue-900 mb-2">
+          <div className="bg-primary-light border border-border rounded-lg p-6 max-w-4xl mx-auto">
+            <h3 className="text-lg font-semibold text-primary mb-2">
               Need Help Choosing?
             </h3>
-            <p className="text-blue-800">
+            <p className="text-primary">
               <strong>Hyatt Orchestrator:</strong> Specialized for hotel and
               hospitality PR campaigns with sequential workflow execution.
               <br />

--- a/frontend/src/components/ReviewPanel.tsx
+++ b/frontend/src/components/ReviewPanel.tsx
@@ -23,24 +23,24 @@ const ReviewPanel: React.FC<ReviewPanelProps> = ({
   return (
     <div className="bg-amber-50 rounded-lg p-6 mb-6 border border-amber-200">
       <div className="text-center mb-4">
-        <h3 className="text-lg font-semibold text-slate-800 mb-2">
+        <h3 className="text-lg font-semibold text-text-primary mb-2">
           🔍 Manual Review Required
         </h3>
-        <p className="text-slate-700">
+        <p className="text-text-primary">
           Awaiting review of the <strong>{phaseName}</strong> phase.
         </p>
-        <p className="text-sm text-slate-600 mt-1">Next: {nextPhase}</p>
+        <p className="text-sm text-text-secondary mt-1">Next: {nextPhase}</p>
       </div>
 
       <div className="flex justify-center space-x-4">
         <button
-          className="px-6 py-2 bg-green-500 hover:bg-green-600 text-white rounded-md transition-colors font-medium"
+          className="px-6 py-2 bg-success hover:bg-success-hover text-white rounded-md transition-colors font-medium"
           onClick={onResume}
         >
           ✅ Resume Campaign
         </button>
         <button
-          className="px-6 py-2 bg-blue-500 hover:bg-blue-600 text-white rounded-md transition-colors font-medium"
+          className="px-6 py-2 bg-primary hover:bg-primary-hover text-white rounded-md transition-colors font-medium"
           onClick={onRefine}
         >
           ✏️ Refine & Retry

--- a/frontend/src/components/WorkflowsPage.tsx
+++ b/frontend/src/components/WorkflowsPage.tsx
@@ -462,13 +462,13 @@ const WorkflowsPage: React.FC = () => {
   console.log("Edges:", hyattEdges);
 
   return (
-    <div className="flex h-[90vh] bg-slate-50 rounded-lg shadow p-4">
+    <div className="flex h-[90vh] bg-secondary rounded-lg shadow p-4">
       {/* Left sidebar */}
-      <div className="w-64 pr-6 border-r border-slate-200 bg-white rounded-l-lg flex flex-col">
+      <div className="w-64 pr-6 border-r border-border bg-white rounded-l-lg flex flex-col">
         <h2 className="text-xl font-bold mb-4 mt-2">Workflows</h2>
         {loading ? (
           <div className="flex-1 flex items-center justify-center">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
           </div>
         ) : (
           <ul className="flex-1">
@@ -478,8 +478,8 @@ const WorkflowsPage: React.FC = () => {
                   <button
                     className={`flex-1 text-left py-2 px-4 rounded-md font-medium transition-colors duration-200 ${
                       selectedWorkflow === orchestration.id
-                        ? "bg-blue-600 text-white"
-                        : "bg-slate-200 text-slate-800 hover:bg-blue-100"
+                        ? "bg-primary text-white"
+                        : "bg-secondary text-text-primary hover:bg-primary-light"
                     }`}
                     onClick={() => setSelectedWorkflow(orchestration.id)}
                   >
@@ -489,7 +489,7 @@ const WorkflowsPage: React.FC = () => {
                     <button
                       onClick={() => handleGenerateDiagram(orchestration.id)}
                       disabled={generatingDiagram === orchestration.id}
-                      className="ml-2 px-3 py-1 text-xs bg-green-600 text-white rounded hover:bg-green-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+                      className="ml-2 px-3 py-1 text-xs bg-success text-white rounded hover:bg-success-hover disabled:bg-secondary disabled:cursor-not-allowed transition-colors"
                     >
                       {generatingDiagram === orchestration.id ? (
                         <div className="animate-spin rounded-full h-3 w-3 border-b-2 border-white"></div>


### PR DESCRIPTION
## Summary
- replace hard-coded colors in GlobalNav, Header toggle, OrchestrationsPage, WorkflowsPage, and ReviewPanel
- use design token classes for primary and success states

## Testing
- `npm run lint:styles` *(fails: stylelint errors)*
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_b_687b8c4ac2c08325994cdb857e01e209