### PR TITLE
Add file generation service and integrate page/component APIs

### DIFF
--- a/frontend/src/components/orchestrations/generated/index.ts
+++ b/frontend/src/components/orchestrations/generated/index.ts
@@ -1,0 +1,18 @@
+// Dynamic orchestration page loader
+export const loadOrchestrationPage = async (orchestrationId: string) => {
+  try {
+    const module = await import(`./${orchestrationId}.tsx`);
+    return module.default;
+  } catch (error) {
+    const { default: GenericOrchestrationPage } = await import("../GenericOrchestrationPage");
+    return GenericOrchestrationPage;
+  }
+};
+
+export interface GeneratedOrchestrationPageProps {
+  orchestrationId: string;
+  orchestrationName: string;
+  hitlReview?: boolean;
+  onToggleHitl?: () => void;
+  onNavigateToOrchestrations?: () => void;
+}

--- a/utils/codeValidator.js
+++ b/utils/codeValidator.js
@@ -1,0 +1,67 @@
+export class CodeValidator {
+  static validateStyling(code) {
+    const hardcodedColorPatterns = [
+      /bg-blue-\d+/g,
+      /bg-green-\d+/g,
+      /bg-gray-\d+/g,
+      /text-blue-\d+/g,
+      /text-green-\d+/g,
+      /text-gray-\d+/g,
+      /border-blue-\d+/g,
+      /border-green-\d+/g,
+      /border-gray-\d+/g,
+    ];
+
+    const violations = [];
+
+    hardcodedColorPatterns.forEach((pattern) => {
+      const matches = code.match(pattern);
+      if (matches) {
+        violations.push({
+          pattern: pattern.source,
+          matches: matches,
+          message: `Hardcoded colors found: ${matches.join(", ")}`,
+        });
+      }
+    });
+
+    return {
+      isValid: violations.length === 0,
+      violations,
+    };
+  }
+
+  static validateReactSyntax(code) {
+    const requiredPatterns = [
+      /import.*React.*from.*['\"]react['\"]/,
+      /export.*default/,
+      /function.*Component|const.*Component.*=/,
+    ];
+
+    const missingPatterns = [];
+
+    requiredPatterns.forEach((pattern) => {
+      if (!pattern.test(code)) {
+        missingPatterns.push(pattern.source);
+      }
+    });
+
+    return {
+      isValid: missingPatterns.length === 0,
+      missingPatterns,
+    };
+  }
+
+  static validateTypeScript(code) {
+    const hasInterface = /interface.*Props/.test(code);
+    const hasTypeAnnotation = /:\s*React\.FC/.test(code);
+
+    return {
+      isValid: hasInterface && hasTypeAnnotation,
+      missing: {
+        interface: !hasInterface,
+        typeAnnotation: !hasTypeAnnotation,
+      },
+    };
+  }
+}

--- a/utils/fileGenerator.js
+++ b/utils/fileGenerator.js
@@ -1,0 +1,60 @@
+import fs from "fs";
+import path from "path";
+
+export class FileGenerator {
+  constructor(baseDir = process.cwd()) {
+    this.baseDir = baseDir;
+    this.generatedDir = path.join(
+      baseDir,
+      "frontend/src/components/orchestrations/generated"
+    );
+  }
+
+  async generateOrchestrationPage(orchestrationId, orchestrationName, pageCode) {
+    await this.ensureDirectoryExists(this.generatedDir);
+
+    const fileName = `${orchestrationId}.tsx`;
+    const filePath = path.join(this.generatedDir, fileName);
+
+    const fullPageCode = `// Auto-generated orchestration page for ${orchestrationName}
+// Generated at: ${new Date().toISOString()}
+// Do not edit manually - regenerate via Orchestration Builder
+
+${pageCode}`;
+
+    await fs.promises.writeFile(filePath, fullPageCode, "utf8");
+
+    await this.updateIndexFile(orchestrationId, orchestrationName);
+
+    return filePath;
+  }
+
+  async ensureDirectoryExists(dirPath) {
+    if (!fs.existsSync(dirPath)) {
+      await fs.promises.mkdir(dirPath, { recursive: true });
+    }
+  }
+
+  async updateIndexFile(orchestrationId, orchestrationName) {
+    const indexPath = path.join(this.generatedDir, "index.ts");
+
+    let indexContent = "";
+    if (fs.existsSync(indexPath)) {
+      indexContent = await fs.promises.readFile(indexPath, "utf8");
+    }
+
+    const exportLine = `export { default as ${orchestrationId}Page } from './${orchestrationId}';`;
+
+    if (!indexContent.includes(exportLine)) {
+      indexContent += `\n${exportLine}`;
+      await fs.promises.writeFile(indexPath, indexContent, "utf8");
+    }
+  }
+
+  async cleanupOrchestrationPage(orchestrationId) {
+    const filePath = path.join(this.generatedDir, `${orchestrationId}.tsx`);
+    if (fs.existsSync(filePath)) {
+      await fs.promises.unlink(filePath);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `utils/fileGenerator.js` and `utils/codeValidator.js`
- create `generated` folder with dynamic loader
- call `generate-page` and `generate-component` APIs from the Orchestration Builder
- show generation progress and errors
- display generated page and component code in preview modal

## Testing
- `npm run lint:styles` *(fails: 333 errors)*

------
https://chatgpt.com/codex/tasks/task_b_687b9f88b5e48325ba9a7c28e4aaca24