### PR TITLE
Complete UI generation integration

### DIFF
--- a/frontend/src/components/orchestrations/OrchestrationBuilderPage.tsx
+++ b/frontend/src/components/orchestrations/OrchestrationBuilderPage.tsx
@@ -140,12 +140,18 @@ const OrchestrationBuilderPage: React.FC<OrchestrationBuilderPageProps> = ({
     if (!generatedOrchestration) return;
 
     try {
+      const saveData = {
+        ...generatedOrchestration,
+        generatedPage: generatedPage,
+        generatedComponent: generatedComponent,
+      };
+
       const response = await fetch("/api/save-orchestration", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify(generatedOrchestration),
+        body: JSON.stringify(saveData),
       });
 
       if (!response.ok) {
@@ -156,8 +162,10 @@ const OrchestrationBuilderPage: React.FC<OrchestrationBuilderPageProps> = ({
       console.log("Orchestration saved:", result);
       setIsBuilderModalOpen(false);
       setGeneratedOrchestration(null);
+      setGeneratedPage(null);
+      setGeneratedComponent(null);
       alert(
-        `Orchestration "${generatedOrchestration.name}" saved successfully!\n\nComplete documentation has been generated and saved to the docs folder.`
+        `Orchestration "${generatedOrchestration.name}" saved successfully!\n\nComplete documentation and UI components have been generated and saved.`
       );
     } catch (error) {
       console.error("Error saving orchestration:", error);


### PR DESCRIPTION
## Summary
- integrate file generation in save-orchestration API
- load generated pages dynamically in the app
- pass generated code to save process in builder

## Testing
- `npm run lint:styles` *(fails: color token violations)*
- `npx vitest run` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_687ba223cf2c832596d89c7543954f78