### PR TITLE
Implement basic dynamic workflow diagram generator

### DIFF
--- a/frontend/src/components/WorkflowsPage.tsx
+++ b/frontend/src/components/WorkflowsPage.tsx
@@ -7,6 +7,8 @@ import ReactFlow, {
   NodeProps,
 } from "reactflow";
 import "reactflow/dist/style.css";
+import { hyattDiagramConfig } from "./orchestrations/diagrams";
+import { diagramToReactFlow } from "../utils/diagramMapper";
 
 const outlinedStyle = {
   background: "#fff",
@@ -201,189 +203,7 @@ const nodeTypes = {
   custom: CustomNode,
 };
 
-// Node positions for diamond/compass layout (PR Manager at center, agents at NE, NW, SE, SW)
-const centerX = 600;
-const centerY = 300;
-const offsetX = 220;
-const offsetY = 160;
-const hyattNodes = [
-  {
-    id: "brief",
-    type: "custom", // changed from 'input' to 'custom'
-    data: { label: "Campaign Brief", style: outlinedStyle },
-    position: { x: centerX - 2 * offsetX, y: centerY },
-  },
-  {
-    id: "pr",
-    type: "custom",
-    data: { label: "PR Manager", style: outlinedStyle },
-    position: { x: centerX, y: centerY },
-  },
-  {
-    id: "research",
-    type: "custom",
-    data: { label: "1. Research", style: outlinedStyle },
-    position: { x: centerX - offsetX, y: centerY - offsetY },
-  },
-  {
-    id: "strategy",
-    type: "custom",
-    data: { label: "2 Stratgy", style: outlinedStyle },
-    position: { x: centerX - offsetX, y: centerY + offsetY },
-  },
-  {
-    id: "trending",
-    type: "custom",
-    data: { label: "3. Trending News", style: outlinedStyle },
-    position: { x: centerX + offsetX, y: centerY - offsetY },
-  },
-  {
-    id: "story",
-    type: "custom",
-    data: { label: "4. Story Angles", style: outlinedStyle },
-    position: { x: centerX + offsetX, y: centerY + offsetY },
-  },
-  {
-    id: "final",
-    type: "custom", // changed from 'output' to 'custom'
-    data: { label: "Final Campaign Strategy", style: outlinedStyle },
-    position: { x: centerX + 2 * offsetX, y: centerY },
-  },
-];
-
-const hyattEdges = [
-  // Black dashed line for brief to PR Manager (horizontal, straight, with arrow)
-  {
-    id: "brief-pr",
-    source: "brief",
-    target: "pr",
-    style: { stroke: "#222", strokeWidth: 2, strokeDasharray: "6 4" },
-    animated: true, // Add animation
-    type: "straight",
-    sourceHandle: "source-right",
-    targetHandle: "target-left",
-  },
-  {
-    id: "pr-final",
-    source: "pr",
-    target: "final",
-    style: { stroke: "#222", strokeWidth: 2, strokeDasharray: "6 4" },
-    animated: true, // Add animation
-    type: "straight",
-    sourceHandle: "source-right",
-    targetHandle: "target-left",
-  },
-  // Research (blue, NW)
-  {
-    id: "pr-research",
-    source: "pr",
-    target: "research",
-    style: {
-      stroke: agentColors.research,
-      strokeWidth: 2,
-      strokeDasharray: "6 4",
-    },
-    animated: true,
-    type: "default",
-  },
-  {
-    id: "research-pr",
-    source: "research",
-    target: "pr",
-    style: {
-      stroke: agentColors.research,
-      strokeWidth: 2,
-      strokeDasharray: "6 4", // Make it dashed
-    },
-    animated: true, // Add animation
-    type: "default",
-    sourceHandle: "source-bottom", // From bottom of Research
-    targetHandle: "target-left", // To left side of PR Manager
-  },
-  // Strategy (pink, SW)
-  {
-    id: "pr-strategy",
-    source: "pr",
-    target: "strategy",
-    style: {
-      stroke: agentColors.strategy,
-      strokeWidth: 2,
-      strokeDasharray: "6 4",
-    },
-    animated: true,
-    type: "default",
-    sourceHandle: "source-bottom", // From bottom of PR Manager
-    targetHandle: "target-right", // To right side of Strategy
-  },
-  {
-    id: "strategy-pr",
-    source: "strategy",
-    target: "pr",
-    style: {
-      stroke: agentColors.strategy,
-      strokeWidth: 2,
-      strokeDasharray: "6 4", // Make it dashed
-    },
-    animated: true, // Add animation
-    type: "default",
-  },
-  // Trending (green, NE)
-  {
-    id: "pr-trending",
-    source: "pr",
-    target: "trending",
-    style: {
-      stroke: agentColors.trending,
-      strokeWidth: 2,
-      strokeDasharray: "6 4",
-    },
-    animated: true,
-    type: "default",
-  },
-  {
-    id: "trending-pr",
-    source: "trending",
-    target: "pr",
-    style: {
-      stroke: agentColors.trending,
-      strokeWidth: 2,
-      strokeDasharray: "6 4", // Make it dashed
-    },
-    animated: true, // Add animation
-    type: "default",
-    sourceHandle: "source-bottom", // From bottom of Trending News
-    targetHandle: "target-right", // To right side of PR Manager
-  },
-  // Story Angles (purple, SE)
-  {
-    id: "pr-story",
-    source: "pr",
-    target: "story",
-    style: {
-      stroke: agentColors.story,
-      strokeWidth: 2,
-      strokeDasharray: "6 4",
-    },
-    animated: true,
-    type: "default",
-    sourceHandle: "source-bottom", // From bottom of PR Manager
-    targetHandle: "target-left", // To left side of Story Angles
-  },
-  {
-    id: "story-pr",
-    source: "story",
-    target: "pr",
-    style: {
-      stroke: agentColors.story,
-      strokeWidth: 2,
-      strokeDasharray: "6 4", // Make it dashed
-    },
-    animated: true, // Add animation
-    type: "default",
-    sourceHandle: "source-top", // From top of Story Angles
-    targetHandle: "target-right", // To right side of PR Manager
-  },
-];
+const { nodes: hyattNodes, edges: hyattEdges } = diagramToReactFlow(hyattDiagramConfig);
 
 const WorkflowsPage: React.FC = () => {
   const [selectedWorkflow, setSelectedWorkflow] = useState<string | null>(
@@ -438,20 +258,28 @@ const WorkflowsPage: React.FC = () => {
   const handleGenerateDiagram = async (orchestrationId: string) => {
     setGeneratingDiagram(orchestrationId);
     try {
-      // TODO: Implement diagram generation API call
-      console.log(`Generating diagram for ${orchestrationId}`);
-      // Simulate API call
-      await new Promise((resolve) => setTimeout(resolve, 2000));
+      const res = await fetch('/api/generate-diagram', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: orchestrationId }),
+      });
+      if (!res.ok) throw new Error('Request failed');
 
-      // Update orchestration to show it now has a diagram
+      const data = await res.json();
+      if (data.diagram) {
+        const { nodes, edges } = diagramToReactFlow(data.diagram);
+        console.log('Generated diagram nodes:', nodes);
+        console.log('Generated diagram edges:', edges);
+      }
+
       setOrchestrations((prev) =>
         prev.map((orch) =>
           orch.id === orchestrationId ? { ...orch, hasDiagram: true } : orch
         )
       );
     } catch (error) {
-      console.error("Failed to generate diagram:", error);
-      alert("Failed to generate diagram. Please try again.");
+      console.error('Failed to generate diagram:', error);
+      alert('Failed to generate diagram. Please try again.');
     } finally {
       setGeneratingDiagram(null);
     }

--- a/frontend/src/components/orchestrations/diagrams/DynamicDiagram.tsx
+++ b/frontend/src/components/orchestrations/diagrams/DynamicDiagram.tsx
@@ -1,0 +1,60 @@
+import { DiagramConfig, DiagramNode, DiagramEdge } from '../../../types/diagram';
+import { createEdgeFromString } from '../../../utils/diagramMapper';
+
+const agentColors: Record<string, string> = {
+  research: '#2563eb',
+  strategy: '#ec4899',
+  trending: '#22c55e',
+  story: '#7c3aed',
+  'pr-manager': '#64748b',
+  visual_prompt_generator: '#f59e0b',
+  modular_elements_recommender: '#06b6d4',
+  trend_cultural_analyzer: '#8b5cf6',
+  brand_qa: '#ef4444',
+};
+
+const calculateNodePosition = (index: number, total: number) => {
+  const centerX = 600;
+  const centerY = 300;
+  const radius = 200;
+  if (total === 1) return { x: centerX, y: centerY };
+  const angle = (index / total) * Math.PI * 2;
+  return { x: centerX + radius * Math.cos(angle), y: centerY + radius * Math.sin(angle) };
+};
+
+const generateNodes = (agents: string[]): DiagramNode[] => {
+  return agents.map((agent, index) => ({
+    id: agent,
+    label: agent,
+    position: calculateNodePosition(index, agents.length),
+    connectors: [
+      { id: `${agent}-T`, position: 'T' },
+      { id: `${agent}-B`, position: 'B' },
+      { id: `${agent}-L`, position: 'L' },
+      { id: `${agent}-R`, position: 'R' },
+    ],
+    style: { border: `2px solid ${agentColors[agent] || '#64748b'}` },
+  }));
+};
+
+const generateSequentialConnections = (agents: string[]): string[] => {
+  const connections: string[] = [];
+  for (let i = 0; i < agents.length - 1; i++) {
+    connections.push(`${agents[i]}:R -> ${agents[i + 1]}:L`);
+  }
+  return connections;
+};
+
+export const generateDiagramFromOrchestration = (orch: any): DiagramConfig => {
+  if (!orch || !Array.isArray(orch.agents) || orch.agents.length === 0) {
+    return {
+      nodes: [{ id: 'empty', label: 'No Agents', position: { x: 600, y: 300 }, connectors: [] }],
+      edges: [],
+    };
+  }
+  const nodes = generateNodes(orch.agents);
+  const edges: DiagramEdge[] = generateSequentialConnections(orch.agents).map((conn) =>
+    createEdgeFromString(conn, { color: '#2563eb', dashed: true, animated: true })
+  );
+  return { nodes, edges };
+};

--- a/frontend/src/components/orchestrations/diagrams/HyattDiagram.tsx
+++ b/frontend/src/components/orchestrations/diagrams/HyattDiagram.tsx
@@ -1,0 +1,180 @@
+import { DiagramConfig } from '../../../types/diagram';
+
+const outlinedStyle = {
+  background: '#fff',
+  border: '2px solid #64748b',
+  color: '#222',
+};
+
+const agentColors = {
+  research: '#2563eb',
+  strategy: '#ec4899',
+  trending: '#22c55e',
+  story: '#7c3aed',
+};
+
+const centerX = 600;
+const centerY = 300;
+const offsetX = 220;
+const offsetY = 160;
+
+export const hyattDiagramConfig: DiagramConfig = {
+  nodes: [
+    {
+      id: 'brief',
+      type: undefined as any,
+      label: 'Campaign Brief',
+      position: { x: centerX - 2 * offsetX, y: centerY },
+      connectors: [
+        { id: 'brief-R', position: 'R' },
+      ],
+      style: outlinedStyle,
+    },
+    {
+      id: 'pr',
+      type: undefined as any,
+      label: 'PR Manager',
+      position: { x: centerX, y: centerY },
+      connectors: [
+        { id: 'pr-T', position: 'T' },
+        { id: 'pr-B', position: 'B' },
+        { id: 'pr-L', position: 'L' },
+        { id: 'pr-R', position: 'R' },
+      ],
+      style: outlinedStyle,
+    },
+    {
+      id: 'research',
+      type: undefined as any,
+      label: '1. Research',
+      position: { x: centerX - offsetX, y: centerY - offsetY },
+      connectors: [
+        { id: 'research-T', position: 'T' },
+        { id: 'research-B', position: 'B' },
+        { id: 'research-L', position: 'L' },
+        { id: 'research-R', position: 'R' },
+      ],
+      style: outlinedStyle,
+    },
+    {
+      id: 'strategy',
+      type: undefined as any,
+      label: '2 Stratgy',
+      position: { x: centerX - offsetX, y: centerY + offsetY },
+      connectors: [
+        { id: 'strategy-T', position: 'T' },
+        { id: 'strategy-B', position: 'B' },
+        { id: 'strategy-L', position: 'L' },
+        { id: 'strategy-R', position: 'R' },
+      ],
+      style: outlinedStyle,
+    },
+    {
+      id: 'trending',
+      type: undefined as any,
+      label: '3. Trending News',
+      position: { x: centerX + offsetX, y: centerY - offsetY },
+      connectors: [
+        { id: 'trending-T', position: 'T' },
+        { id: 'trending-B', position: 'B' },
+        { id: 'trending-L', position: 'L' },
+        { id: 'trending-R', position: 'R' },
+      ],
+      style: outlinedStyle,
+    },
+    {
+      id: 'story',
+      type: undefined as any,
+      label: '4. Story Angles',
+      position: { x: centerX + offsetX, y: centerY + offsetY },
+      connectors: [
+        { id: 'story-T', position: 'T' },
+        { id: 'story-B', position: 'B' },
+        { id: 'story-L', position: 'L' },
+        { id: 'story-R', position: 'R' },
+      ],
+      style: outlinedStyle,
+    },
+    {
+      id: 'final',
+      type: undefined as any,
+      label: 'Final Campaign Strategy',
+      position: { x: centerX + 2 * offsetX, y: centerY },
+      connectors: [
+        { id: 'final-L', position: 'L' },
+      ],
+      style: outlinedStyle,
+    },
+  ],
+  edges: [
+    // Black dashed line for brief to PR Manager (horizontal, straight)
+    {
+      id: 'brief-pr',
+      from: { nodeId: 'brief', connector: 'R' },
+      to: { nodeId: 'pr', connector: 'L' },
+      style: { strokeWidth: 2, color: '#222', dashed: true, animated: true },
+      type: 'straight',
+    },
+    {
+      id: 'pr-final',
+      from: { nodeId: 'pr', connector: 'R' },
+      to: { nodeId: 'final', connector: 'L' },
+      style: { strokeWidth: 2, color: '#222', dashed: true, animated: true },
+      type: 'straight',
+    },
+    // Research (blue)
+    {
+      id: 'pr-research',
+      from: { nodeId: 'pr', connector: 'T' },
+      to: { nodeId: 'research', connector: 'B' },
+      style: { strokeWidth: 2, color: agentColors.research, dashed: true, animated: true },
+    },
+    {
+      id: 'research-pr',
+      from: { nodeId: 'research', connector: 'B' },
+      to: { nodeId: 'pr', connector: 'L' },
+      style: { strokeWidth: 2, color: agentColors.research, dashed: true, animated: true },
+    },
+    // Strategy (pink)
+    {
+      id: 'pr-strategy',
+      from: { nodeId: 'pr', connector: 'B' },
+      to: { nodeId: 'strategy', connector: 'R' },
+      style: { strokeWidth: 2, color: agentColors.strategy, dashed: true, animated: true },
+    },
+    {
+      id: 'strategy-pr',
+      from: { nodeId: 'strategy', connector: 'T' },
+      to: { nodeId: 'pr', connector: 'L' },
+      style: { strokeWidth: 2, color: agentColors.strategy, dashed: true, animated: true },
+    },
+    // Trending (green)
+    {
+      id: 'pr-trending',
+      from: { nodeId: 'pr', connector: 'T' },
+      to: { nodeId: 'trending', connector: 'B' },
+      style: { strokeWidth: 2, color: agentColors.trending, dashed: true, animated: true },
+    },
+    {
+      id: 'trending-pr',
+      from: { nodeId: 'trending', connector: 'B' },
+      to: { nodeId: 'pr', connector: 'R' },
+      style: { strokeWidth: 2, color: agentColors.trending, dashed: true, animated: true },
+    },
+    // Story Angles (purple)
+    {
+      id: 'pr-story',
+      from: { nodeId: 'pr', connector: 'B' },
+      to: { nodeId: 'story', connector: 'L' },
+      style: { strokeWidth: 2, color: agentColors.story, dashed: true, animated: true },
+    },
+    {
+      id: 'story-pr',
+      from: { nodeId: 'story', connector: 'T' },
+      to: { nodeId: 'pr', connector: 'R' },
+      style: { strokeWidth: 2, color: agentColors.story, dashed: true, animated: true },
+    },
+  ],
+};
+
+export default hyattDiagramConfig;

--- a/frontend/src/components/orchestrations/diagrams/index.ts
+++ b/frontend/src/components/orchestrations/diagrams/index.ts
@@ -1,0 +1,2 @@
+export { default as hyattDiagramConfig } from './HyattDiagram';
+export * from './DynamicDiagram';

--- a/pages/api/generate-diagram.js
+++ b/pages/api/generate-diagram.js
@@ -1,0 +1,97 @@
+const agentColors = {
+  research: '#2563eb',
+  strategy: '#ec4899',
+  trending: '#22c55e',
+  story: '#7c3aed',
+  'pr-manager': '#64748b',
+  visual_prompt_generator: '#f59e0b',
+  modular_elements_recommender: '#06b6d4',
+  trend_cultural_analyzer: '#8b5cf6',
+  brand_qa: '#ef4444',
+};
+
+const calculateNodePosition = (index, total) => {
+  const centerX = 600;
+  const centerY = 300;
+  const radius = 200;
+  if (total === 1) return { x: centerX, y: centerY };
+  const angle = (index / total) * Math.PI * 2;
+  return {
+    x: centerX + radius * Math.cos(angle),
+    y: centerY + radius * Math.sin(angle),
+  };
+};
+
+const generateNodes = (agents) => {
+  return agents.map((agent, index) => ({
+    id: agent,
+    label: agent,
+    position: calculateNodePosition(index, agents.length),
+    connectors: [
+      { id: `${agent}-T`, position: 'T' },
+      { id: `${agent}-B`, position: 'B' },
+      { id: `${agent}-L`, position: 'L' },
+      { id: `${agent}-R`, position: 'R' },
+    ],
+    style: { border: `2px solid ${agentColors[agent] || '#64748b'}` },
+  }));
+};
+
+const generateSequentialConnections = (agents) => {
+  const connections = [];
+  for (let i = 0; i < agents.length - 1; i++) {
+    connections.push(`${agents[i]}:R -> ${agents[i + 1]}:L`);
+  }
+  return connections;
+};
+
+const parseConnection = (conn) => {
+  const [nodeId, connector] = conn.split(':');
+  return { nodeId, connector };
+};
+
+const createEdgeFromString = (str) => {
+  const [from, to] = str.split('->').map((s) => s.trim());
+  const fromConn = parseConnection(from);
+  const toConn = parseConnection(to);
+  return {
+    id: `${from}-${to}`,
+    from: fromConn,
+    to: toConn,
+    style: { color: '#2563eb', dashed: true, animated: true, strokeWidth: 2 },
+    type: 'default',
+  };
+};
+
+const generateDiagramFromOrchestration = (orch) => {
+  if (!orch || !Array.isArray(orch.agents) || orch.agents.length === 0) {
+    return {
+      nodes: [{ id: 'empty', label: 'No Agents', position: { x: 600, y: 300 }, connectors: [] }],
+      edges: [],
+    };
+  }
+  const nodes = generateNodes(orch.agents);
+  const edges = generateSequentialConnections(orch.agents).map(createEdgeFromString);
+  return { nodes, edges };
+};
+
+export default function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).json({ message: 'Method not allowed' });
+
+  try {
+    const { id } = req.body;
+    if (!id) return res.status(400).json({ message: 'Missing id' });
+    const orchestrations = {
+      hyatt: { agents: ['pr_manager', 'research_audience', 'strategic_insight', 'trending_news', 'story_angles'] },
+      hive: { agents: ['pr_manager', 'research_audience', 'strategic_insight', 'trending_news', 'story_angles'] },
+      template: { agents: ['pr_manager', 'research_audience', 'strategic_insight', 'trending_news'] },
+    };
+    const orchestration = orchestrations[id];
+    if (!orchestration) return res.status(404).json({ message: 'Not found' });
+    const diagram = generateDiagramFromOrchestration(orchestration);
+    res.status(200).json({ diagram });
+  } catch (err) {
+    console.error('Diagram generation failed:', err);
+    res.status(500).json({ message: 'Failed to generate diagram' });
+  }
+}

--- a/pages/api/orchestrations.js
+++ b/pages/api/orchestrations.js
@@ -50,6 +50,7 @@ export default function handler(req, res) {
           "trending_news",
           "story_angles",
         ],
+        hasDiagram: true,
       },
       template: {
         id: "template",
@@ -69,6 +70,7 @@ export default function handler(req, res) {
           "strategic_insight",
           "trending_news",
         ],
+        hasDiagram: false,
       },
       builder: {
         id: "builder",
@@ -88,6 +90,7 @@ export default function handler(req, res) {
           "agent_generator",
           "workflow_designer",
         ],
+        hasDiagram: false,
       },
       hive: {
         id: "hive",
@@ -118,6 +121,7 @@ export default function handler(req, res) {
           "brand_qa",
           "modular_elements_recommender",
         ],
+        hasDiagram: false,
       },
     };
 


### PR DESCRIPTION
## Summary
- add Hyatt diagram config and generation utilities
- expose diagram generation API endpoint
- integrate diagram config into WorkflowsPage
- allow generating a diagram via `/api/generate-diagram`
- add diagram metadata in orchestrations API

## Testing
- `npm run lint:styles` *(fails: Unexpected named color etc.)*

------
https://chatgpt.com/codex/tasks/task_b_687bab68600483259975d04af1bbe622