### PR TITLE
Implement basic tabbed interface

### DIFF
--- a/frontend/src/components/WorkflowsPage.tsx
+++ b/frontend/src/components/WorkflowsPage.tsx
@@ -195,9 +195,55 @@ const nodeTypes = {
 const { nodes: hyattNodes, edges: hyattEdges } =
   diagramToReactFlow(hyattDiagramConfig);
 
+interface TabNavigationProps {
+  activeTab: "workflow" | "details" | "edit";
+  onTabChange: (tab: "workflow" | "details" | "edit") => void;
+}
+
+const TabNavigation: React.FC<TabNavigationProps> = ({
+  activeTab,
+  onTabChange,
+}) => (
+  <div className="flex space-x-1 mb-4">
+    <button
+      onClick={() => onTabChange("workflow")}
+      className={`px-4 py-2 rounded-t-lg font-medium transition-colors ${
+        activeTab === "workflow"
+          ? "bg-white text-primary border-b-2 border-primary"
+          : "bg-secondary text-text-secondary hover:bg-primary-light"
+      }`}
+    >
+      Workflow
+    </button>
+    <button
+      onClick={() => onTabChange("details")}
+      className={`px-4 py-2 rounded-t-lg font-medium transition-colors ${
+        activeTab === "details"
+          ? "bg-white text-primary border-b-2 border-primary"
+          : "bg-secondary text-text-secondary hover:bg-primary-light"
+      }`}
+    >
+      Details
+    </button>
+    <button
+      onClick={() => onTabChange("edit")}
+      className={`px-4 py-2 rounded-t-lg font-medium transition-colors ${
+        activeTab === "edit"
+          ? "bg-white text-primary border-b-2 border-primary"
+          : "bg-secondary text-text-secondary hover:bg-primary-light"
+      }`}
+    >
+      Edit
+    </button>
+  </div>
+);
+
 const WorkflowsPage: React.FC = () => {
   const [selectedWorkflow, setSelectedWorkflow] = useState<string | null>(
     "hyatt"
+  );
+  const [activeTab, setActiveTab] = useState<"workflow" | "details" | "edit">(
+    "workflow"
   );
 
   // State for orchestrations and diagrams
@@ -334,59 +380,76 @@ const WorkflowsPage: React.FC = () => {
       </div>
       {/* Right content pane */}
       <div className="flex-1 pl-6 flex flex-col">
-        {selectedWorkflow && hasDiagramForDisplay(selectedWorkflow) ? (
-          <div className="border rounded-lg p-6 bg-white shadow flex-1">
-            <h3 className="text-xl font-semibold mb-4">
-              {orchestrations.find((o) => o.id === selectedWorkflow)?.name ||
-                selectedWorkflow}{" "}
-              Workflow Diagram
-            </h3>
-            <div style={{ width: "100%", height: "800px", minWidth: "1400px" }}>
-              <ReactFlow
-                nodes={hyattNodes}
-                edges={hyattEdges}
-                nodeTypes={nodeTypes}
-                fitView
-                nodesDraggable={false}
-                nodesConnectable={false}
-                elementsSelectable={false}
-                panOnDrag={true}
-                zoomOnScroll={true}
-                zoomOnPinch={true}
-                zoomOnDoubleClick={false}
-                panOnScroll={true}
-              >
-                <Background />
-                <Controls showInteractive={false} />
-              </ReactFlow>
-            </div>
-          </div>
-        ) : selectedWorkflow ? (
-          <div className="border rounded-lg p-6 bg-white shadow flex-1 flex items-center justify-center">
-            <div className="text-center">
-              <h3 className="text-xl font-semibold mb-4">
-                {orchestrations.find((o) => o.id === selectedWorkflow)?.name ||
-                  selectedWorkflow}
-              </h3>
-              <p className="text-text-muted mb-4">
-                No workflow diagram available for this orchestration.
-              </p>
-              <button
-                onClick={() => handleGenerateDiagram(selectedWorkflow)}
-                disabled={generatingDiagram === selectedWorkflow}
-                className="px-4 py-2 bg-success text-white rounded hover:bg-success-hover disabled:bg-secondary disabled:cursor-not-allowed transition-colors"
-              >
-                {generatingDiagram === selectedWorkflow ? (
-                  <div className="flex items-center space-x-2">
-                    <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
-                    <span>Generating Diagram...</span>
+        {selectedWorkflow ? (
+          <>
+            <TabNavigation activeTab={activeTab} onTabChange={setActiveTab} />
+            {activeTab === "workflow" && (
+              hasDiagramForDisplay(selectedWorkflow) ? (
+                <div className="border rounded-lg p-6 bg-white shadow flex-1">
+                  <h3 className="text-xl font-semibold mb-4">
+                    {orchestrations.find((o) => o.id === selectedWorkflow)?.name ||
+                      selectedWorkflow}{" "}
+                    Workflow Diagram
+                  </h3>
+                  <div style={{ width: "100%", height: "800px", minWidth: "1400px" }}>
+                    <ReactFlow
+                      nodes={hyattNodes}
+                      edges={hyattEdges}
+                      nodeTypes={nodeTypes}
+                      fitView
+                      nodesDraggable={false}
+                      nodesConnectable={false}
+                      elementsSelectable={false}
+                      panOnDrag={true}
+                      zoomOnScroll={true}
+                      zoomOnPinch={true}
+                      zoomOnDoubleClick={false}
+                      panOnScroll={true}
+                    >
+                      <Background />
+                      <Controls showInteractive={false} />
+                    </ReactFlow>
                   </div>
-                ) : (
-                  "Generate Workflow Diagram"
-                )}
-              </button>
-            </div>
-          </div>
+                </div>
+              ) : (
+                <div className="border rounded-lg p-6 bg-white shadow flex-1 flex items-center justify-center">
+                  <div className="text-center">
+                    <h3 className="text-xl font-semibold mb-4">
+                      {orchestrations.find((o) => o.id === selectedWorkflow)?.name ||
+                        selectedWorkflow}
+                    </h3>
+                    <p className="text-text-muted mb-4">
+                      No workflow diagram available for this orchestration.
+                    </p>
+                    <button
+                      onClick={() => handleGenerateDiagram(selectedWorkflow)}
+                      disabled={generatingDiagram === selectedWorkflow}
+                      className="px-4 py-2 bg-success text-white rounded hover:bg-success-hover disabled:bg-secondary disabled:cursor-not-allowed transition-colors"
+                    >
+                      {generatingDiagram === selectedWorkflow ? (
+                        <div className="flex items-center space-x-2">
+                          <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
+                          <span>Generating Diagram...</span>
+                        </div>
+                      ) : (
+                        "Generate Workflow Diagram"
+                      )}
+                    </button>
+                  </div>
+                </div>
+              )
+            )}
+            {activeTab === "details" && (
+              <div className="border rounded-lg p-6 bg-white shadow flex-1 flex items-center justify-center">
+                <span className="text-text-secondary">Documentation loading...</span>
+              </div>
+            )}
+            {activeTab === "edit" && (
+              <div className="border rounded-lg p-6 bg-white shadow flex-1 flex items-center justify-center">
+                <span className="text-text-secondary">Edit functionality coming soon</span>
+              </div>
+            )}
+          </>
         ) : (
           <div className="border rounded-lg p-6 bg-white shadow flex-1 flex items-center justify-center">
             <p className="text-text-muted">


### PR DESCRIPTION
## Summary
- add tab state to `WorkflowsPage`
- implement `TabNavigation` with design tokens
- display placeholders for Details/Edit tabs

## Testing
- `npm test --prefix frontend` *(fails: 5 failing tests)*
- `npm run lint:styles` *(fails: stylelint errors)*

------
https://chatgpt.com/codex/tasks/task_b_687bc325631083258fee057cdb2d261e