### PR TITLE
Fix orchestration agent IDs

### DIFF
--- a/pages/api/orchestrations.js
+++ b/pages/api/orchestrations.js
@@ -64,28 +64,6 @@ export default function handler(req, res) {
         hasDiagram: false,
         hasDocumentation: false,
       },
-      builder: {
-        id: "builder",
-        name: "Orchestration Builder",
-        description:
-          "AI-powered orchestration generator. Describe what you want, and it creates a custom orchestration for you.",
-        enabled: true,
-        config: {
-          maxConcurrentWorkflows: 3,
-          timeout: 300000,
-          retryAttempts: 2,
-          enableLogging: true,
-        },
-        workflows: ["orchestration_generation_workflow"],
-        agents: [
-          "orchestration_analyzer",
-          "agent_generator",
-          "workflow_designer",
-        ],
-        hasDiagram: false,
-        hasDocumentation: true,
-        documentationPath: "docs/orchestrations/OrchestrationBuilder.md",
-      },
       hive: {
         id: "hive",
         name: "Hive Orchestrator",


### PR DESCRIPTION
## Summary
- remove the fictional Builder orchestration
- ensure all base orchestrations use hyphenated agent IDs

## Testing
- `npm run lint:styles` *(fails: stylelint not found)*
- `npm run lint` in frontend *(fails: cannot find @eslint/js)*
- `npm install --silent` *(no output due to env restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_687c9ec28714832588cd0d6731117877