### PR TITLE
Implement validation and multi-agent generation

### DIFF
--- a/hive/agents/index.js
+++ b/hive/agents/index.js
@@ -1,16 +1,44 @@
-// Consolidated Agents Module
-// This module exports all agent classes from the consolidated structure
+const fs = require('fs').promises;
+const path = require('path');
 
-const PRManagerAgent = require("./classes/PRManagerAgent");
-const ResearchAudienceAgent = require("./classes/ResearchAudienceAgent");
-const TrendingNewsAgent = require("./classes/TrendingNewsAgent");
-const StoryAnglesAgent = require("./classes/StoryAnglesAgent");
-const StrategicInsightAgent = require("./classes/StrategicInsightAgent");
+class AgentRegistry {
+  static async loadAllAgents() {
+    const agentsDir = path.join(__dirname, 'classes');
+    const agentFiles = await fs.readdir(agentsDir);
+    const agents = {};
+    for (const file of agentFiles) {
+      if (file.endsWith('.js') && file !== 'BaseAgent.js') {
+        const agentId = file.replace('.js', '').toLowerCase();
+        try {
+          const AgentClass = require(`./classes/${file}`);
+          agents[agentId] = AgentClass;
+        } catch (error) {
+          console.warn(`Failed to load agent ${agentId}:`, error.message);
+        }
+      }
+    }
+    return agents;
+  }
 
-module.exports = {
-  PRManagerAgent,
-  ResearchAudienceAgent,
-  TrendingNewsAgent,
-  StoryAnglesAgent,
-  StrategicInsightAgent,
-};
+  static async registerNewAgent(agentId, agentClass) {
+    const OrchestrationManager = require('../orchestrations/OrchestrationManager');
+    const manager = new OrchestrationManager();
+    await manager.reloadAgentsConfig();
+    return {
+      registered: true,
+      agentId,
+      className: agentClass.className,
+    };
+  }
+
+  static async getExistingAgentIds() {
+    const configPath = path.join(__dirname, 'agents.config.json');
+    if (!require('fs').existsSync(configPath)) {
+      return [];
+    }
+    const config = JSON.parse(await fs.readFile(configPath, 'utf8'));
+    return Object.keys(config.agents || {});
+  }
+}
+
+module.exports = AgentRegistry;

--- a/utils/agentTester.js
+++ b/utils/agentTester.js
@@ -1,0 +1,34 @@
+class AgentTester {
+  static async testGeneratedAgent(agentId, agentClass) {
+    try {
+      const AgentClass = require(`../hive/agents/classes/${agentClass.className}.js`);
+      const agent = new AgentClass();
+      await agent.loadSystemPrompt();
+      const result = await agent.process("test input");
+      return {
+        isValid: true,
+        result,
+        agentId,
+        className: agentClass.className,
+      };
+    } catch (error) {
+      return {
+        isValid: false,
+        error: error.message,
+        agentId,
+        className: agentClass.className,
+      };
+    }
+  }
+
+  static async testAllGeneratedAgents(generatedAgents) {
+    const testResults = [];
+    for (const agent of generatedAgents) {
+      const result = await this.testGeneratedAgent(agent.agentId, agent.agentClass);
+      testResults.push(result);
+    }
+    return testResults;
+  }
+}
+
+module.exports = AgentTester;

--- a/utils/agentValidator.js
+++ b/utils/agentValidator.js
@@ -1,0 +1,59 @@
+class AgentValidator {
+  static validateAgentClass(classCode) {
+    const errors = [];
+
+    // Check for BaseAgent extension
+    if (!classCode.includes("extends BaseAgent")) {
+      errors.push("Agent must extend BaseAgent class");
+    }
+
+    // Check for required methods
+    if (!classCode.includes("process")) {
+      errors.push("Agent must implement process method");
+    }
+
+    // Check for proper imports
+    if (!classCode.includes("require(\"./BaseAgent\")") && !classCode.includes("require('./BaseAgent')")) {
+      errors.push("Agent must import BaseAgent");
+    }
+
+    // Check for proper exports
+    if (!classCode.includes("module.exports")) {
+      errors.push("Agent must export the class");
+    }
+
+    // Responses API validation
+    if (classCode.includes("chat.completions.create")) {
+      errors.push("Agent MUST use responses.create() NOT chat.completions.create()");
+    }
+    if (!classCode.includes("responses.create")) {
+      errors.push("Agent MUST use openai.responses.create() API");
+    }
+    if (classCode.includes('"messages"')) {
+      errors.push("Agent MUST use 'input' parameter NOT 'messages'");
+    }
+    if (classCode.includes("choices[0].message.content")) {
+      errors.push("Agent MUST use response.output_text NOT completion.choices[0].message.content");
+    }
+
+    return { isValid: errors.length === 0, errors };
+  }
+
+  static validateAgentPrompt(promptCode) {
+    const errors = [];
+
+    // Check for markdown structure
+    if (!promptCode.includes("#")) {
+      errors.push("Prompt must include markdown headers");
+    }
+
+    // Check for purpose section
+    if (!promptCode.toLowerCase().includes("purpose")) {
+      errors.push("Prompt must include purpose section");
+    }
+
+    return { isValid: errors.length === 0, errors };
+  }
+}
+
+module.exports = AgentValidator;


### PR DESCRIPTION
## Summary
- add agent validation logic
- implement agent tester for simple runtime checks
- update agent registry for dynamic loading
- support multiple agents in generation route with validation and testing

## Testing
- `npm run lint:styles` *(fails: stylelint not found or CSS rule errors)*

------
https://chatgpt.com/codex/tasks/task_b_687d0d6bd74c8325917f8b607aa197d4