### PR TITLE
Add orchestration generator modules

### DIFF
--- a/frontend/src/components/OrchestrationsPage.tsx
+++ b/frontend/src/components/OrchestrationsPage.tsx
@@ -84,9 +84,9 @@ const OrchestrationsPage: React.FC<OrchestrationsPageProps> = ({
               },
               workflows: ["orchestration_generation_workflow"],
               agents: [
-                "orchestration_analyzer",
-                "agent_generator",
-                "workflow_designer",
+                "research",
+                "strategic",
+                "pr-manager",
               ],
             },
             {

--- a/hive/routes/generation.js
+++ b/hive/routes/generation.js
@@ -753,4 +753,30 @@ Output: "processed: hello"`;
       };
     }
   }
+
+  app.post("/api/generate-orchestration-pipeline", async (req, res) => {
+    if (req.method !== "POST")
+      return res.status(405).json({ error: "Method not allowed" });
+    try {
+      const { description } = req.body;
+      if (!description)
+        return res.status(400).json({ error: "Description is required" });
+
+      const AutomatedGenerationPipeline = require("../../utils/automatedGenerationPipeline");
+
+      const result = await AutomatedGenerationPipeline.generateProductionReadyOrchestration(description);
+      if (result.success) {
+        res.status(200).json(result);
+      } else {
+        res.status(500).json(result);
+      }
+    } catch (error) {
+      console.error("Pipeline generation failed:", error);
+      res.status(500).json({
+        success: false,
+        error: error.message,
+        pipeline: { steps: ["Generation failed"], errors: [error.message] },
+      });
+    }
+  });
 };

--- a/utils/ConfigGenerator.js
+++ b/utils/ConfigGenerator.js
@@ -1,0 +1,82 @@
+const fs = require("fs/promises");
+const path = require("path");
+
+class ConfigGenerator {
+  static async generateOrchestrationConfig(orchestration) {
+    const config = {
+      id: orchestration.id,
+      name: orchestration.name,
+      description: orchestration.description,
+      enabled: true,
+      config: {
+        maxConcurrentWorkflows: 5,
+        timeout: 300000,
+        retryAttempts: 3,
+        enableLogging: true,
+      },
+      workflows: orchestration.workflows || [],
+      agents: orchestration.agents || [],
+      hasDiagram: orchestration.hasDiagram || false,
+      hasDocumentation: orchestration.hasDocumentation || false,
+      documentationPath: orchestration.documentationPath,
+    };
+    return config;
+  }
+
+  static async generateAgentConfig(agent) {
+    const config = {
+      id: agent.id,
+      name: agent.name,
+      description: agent.description,
+      enabled: true,
+      model: agent.model || "gpt-4o-2024-08-06",
+      temperature: agent.temperature || 0.7,
+      maxTokens: agent.maxTokens || 2000,
+      timeout: agent.timeout || 45000,
+      delay: agent.delay || 4000,
+      promptFile: agent.promptFile,
+      role: agent.role,
+      priority: agent.priority || 1,
+    };
+    return config;
+  }
+
+  static async saveOrchestrationConfig(orchestrationConfig) {
+    const configPath = path.join(
+      process.cwd(),
+      "hive",
+      "orchestrations",
+      "configs",
+      "orchestrations.config.json"
+    );
+    const existingConfig = await this.loadExistingConfig(configPath);
+    existingConfig.orchestrations[orchestrationConfig.id] = orchestrationConfig;
+    await fs.writeFile(configPath, JSON.stringify(existingConfig, null, 2));
+  }
+
+  static async saveAgentConfig(agentConfig) {
+    const configPath = path.join(
+      process.cwd(),
+      "hive",
+      "agents",
+      "agents.config.json"
+    );
+    const existingConfig = await this.loadExistingConfig(configPath);
+    existingConfig.agents[agentConfig.id] = agentConfig;
+    await fs.writeFile(configPath, JSON.stringify(existingConfig, null, 2));
+  }
+
+  static async loadExistingConfig(configPath) {
+    try {
+      const configData = await fs.readFile(configPath, "utf8");
+      return JSON.parse(configData);
+    } catch (error) {
+      return {
+        orchestrations: {},
+        agents: {},
+      };
+    }
+  }
+}
+
+module.exports = ConfigGenerator;

--- a/utils/ConfigMaintenanceManager.js
+++ b/utils/ConfigMaintenanceManager.js
@@ -1,0 +1,179 @@
+const fs = require("fs/promises");
+const path = require("path");
+
+class ConfigMaintenanceManager {
+  static async maintainAllConfigs(generatedOrchestration) {
+    const maintenanceTasks = [
+      this.updateServerAllowedFiles,
+      this.updateAgentConfigs,
+      this.updateOrchestrationConfigs,
+      this.updateAPIEndpoints,
+      this.updatePromptEndpoints,
+    ];
+
+    const results = {
+      success: true,
+      updatedFiles: [],
+      errors: [],
+      warnings: [],
+    };
+
+    for (const task of maintenanceTasks) {
+      try {
+        const result = await task.call(this, generatedOrchestration);
+        results.updatedFiles.push(...(result.updatedFiles || []));
+        if (result.warnings) results.warnings.push(...result.warnings);
+      } catch (error) {
+        results.errors.push(`Task ${task.name} failed: ${error.message}`);
+        results.success = false;
+      }
+    }
+
+    return results;
+  }
+
+  static async updateServerAllowedFiles(generatedOrchestration) {
+    const serverPath = path.join(process.cwd(), "hive", "server.js");
+    const serverContent = await fs.readFile(serverPath, "utf8");
+
+    const allowedFilesMatch = serverContent.match(
+      /const allowedFiles = \[([\s\S]*?)\];/
+    );
+
+    if (!allowedFilesMatch) {
+      throw new Error("Could not find allowedFiles array in server.js");
+    }
+
+    const currentAllowedFiles = allowedFilesMatch[1]
+      .split(",")
+      .map((file) => file.trim().replace(/"/g, ""))
+      .filter((file) => file.length > 0);
+
+    const newPromptFiles = [];
+    for (const agent of generatedOrchestration.agents || []) {
+      if (agent.promptFile && !currentAllowedFiles.includes(agent.promptFile)) {
+        newPromptFiles.push(agent.promptFile);
+      }
+    }
+
+    if (newPromptFiles.length > 0) {
+      const updatedAllowedFiles = [...currentAllowedFiles, ...newPromptFiles];
+      const updatedArray = `const allowedFiles = [\n      ${updatedAllowedFiles
+        .map((file) => `"${file}"`)
+        .join(",\n      ")}\n    ];`;
+
+      const updatedServerContent = serverContent.replace(
+        /const allowedFiles = \[[\s\S]*?\];/,
+        updatedArray
+      );
+
+      await fs.writeFile(serverPath, updatedServerContent);
+
+      return {
+        updatedFiles: [serverPath],
+        warnings: [
+          `Added ${newPromptFiles.length} new prompt files to server allowedFiles`,
+        ],
+      };
+    }
+
+    return { updatedFiles: [], warnings: [] };
+  }
+
+  static async updateAgentConfigs(generatedOrchestration) {
+    const configPath = path.join(
+      process.cwd(),
+      "hive",
+      "agents",
+      "agents.config.json"
+    );
+    const config = JSON.parse(await fs.readFile(configPath, "utf8"));
+
+    const newAgents = [];
+    for (const agent of generatedOrchestration.agents || []) {
+      if (!config.agents[agent.id]) {
+        config.agents[agent.id] = {
+          name: agent.name,
+          description: agent.description,
+          enabled: true,
+          model: agent.model || "gpt-4o-2024-08-06",
+          temperature: agent.temperature || 0.7,
+          maxTokens: agent.maxTokens || 2000,
+          timeout: agent.timeout || 45000,
+          delay: agent.delay || 4000,
+          promptFile: agent.promptFile,
+          role: agent.role,
+          priority: agent.priority || 1,
+        };
+        newAgents.push(agent.id);
+      }
+    }
+
+    if (newAgents.length > 0) {
+      await fs.writeFile(configPath, JSON.stringify(config, null, 2));
+      return {
+        updatedFiles: [configPath],
+        warnings: [`Added ${newAgents.length} new agents to config`],
+      };
+    }
+
+    return { updatedFiles: [], warnings: [] };
+  }
+
+  static async updateOrchestrationConfigs(generatedOrchestration) {
+    const configPath = path.join(
+      process.cwd(),
+      "hive",
+      "orchestrations",
+      "configs",
+      "orchestrations.config.json"
+    );
+
+    let config;
+    try {
+      config = JSON.parse(await fs.readFile(configPath, "utf8"));
+    } catch (error) {
+      config = { orchestrations: {} };
+    }
+
+    if (!config.orchestrations[generatedOrchestration.id]) {
+      config.orchestrations[generatedOrchestration.id] = {
+        id: generatedOrchestration.id,
+        name: generatedOrchestration.name,
+        description: generatedOrchestration.description,
+        enabled: true,
+        config: {
+          maxConcurrentWorkflows: 5,
+          timeout: 300000,
+          retryAttempts: 3,
+          enableLogging: true,
+        },
+        workflows: generatedOrchestration.workflows || [],
+        agents: generatedOrchestration.agents || [],
+        hasDiagram: generatedOrchestration.hasDiagram || false,
+        hasDocumentation: generatedOrchestration.hasDocumentation || false,
+        documentationPath: generatedOrchestration.documentationPath,
+      };
+
+      await fs.writeFile(configPath, JSON.stringify(config, null, 2));
+      return {
+        updatedFiles: [configPath],
+        warnings: [
+          `Added new orchestration ${generatedOrchestration.id} to config`,
+        ],
+      };
+    }
+
+    return { updatedFiles: [], warnings: [] };
+  }
+
+  static async updateAPIEndpoints() {
+    return { updatedFiles: [], warnings: [] };
+  }
+
+  static async updatePromptEndpoints() {
+    return { updatedFiles: [], warnings: [] };
+  }
+}
+
+module.exports = ConfigMaintenanceManager;

--- a/utils/automatedGenerationPipeline.js
+++ b/utils/automatedGenerationPipeline.js
@@ -1,0 +1,136 @@
+const fs = require("fs/promises");
+const ConfigMaintenanceManager = require("./ConfigMaintenanceManager");
+const PostProcessingValidator = require("./postProcessingValidator");
+
+class AutomatedGenerationPipeline {
+  static async generateProductionReadyOrchestration(brief) {
+    const pipeline = {
+      steps: [],
+      errors: [],
+      warnings: [],
+      generatedFiles: [],
+    };
+
+    try {
+      pipeline.steps.push("Generating orchestration specification...");
+      const orchestration = await this.generateOrchestration(brief);
+
+      pipeline.steps.push("Generating missing agents...");
+      const agents = await this.generateAgentsWithValidation(orchestration.agents);
+
+      pipeline.steps.push("Generating React page...");
+      const page = await this.generatePageWithPostProcessing(orchestration);
+
+      pipeline.steps.push("Generating UI components...");
+      const components = await this.generateComponentsWithPostProcessing(orchestration);
+
+      pipeline.steps.push("Validating complete orchestration...");
+      const validation = await this.validateCompleteOrchestration({
+        orchestration,
+        agents,
+        page,
+        components,
+      });
+
+      if (!validation.isValid) {
+        throw new Error(`Validation failed: ${validation.errors.join(", ")}`);
+      }
+
+      pipeline.steps.push("Maintaining system configs...");
+      const configMaintenance = await ConfigMaintenanceManager.maintainAllConfigs({
+        ...orchestration,
+        agents,
+        page,
+        components,
+      });
+
+      if (!configMaintenance.success) {
+        throw new Error(`Config maintenance failed: ${configMaintenance.errors.join(", ")}`);
+      }
+
+      pipeline.steps.push("Saving orchestration and files...");
+      const savedFiles = await this.saveAllFiles({ orchestration, agents, page, components });
+
+      pipeline.generatedFiles = savedFiles;
+      pipeline.configMaintenance = configMaintenance;
+      pipeline.steps.push("Orchestration generation completed successfully!");
+
+      return {
+        success: true,
+        pipeline,
+        orchestration: { ...orchestration, agents, page, components, files: savedFiles },
+      };
+    } catch (error) {
+      pipeline.errors.push(error.message);
+      pipeline.steps.push("Generation failed - rolling back changes...");
+      await this.rollbackGeneration(pipeline.generatedFiles);
+      return { success: false, pipeline, error: error.message };
+    }
+  }
+
+  static async generatePageWithPostProcessing(orchestration) {
+    const pageResponse = await fetch("/api/generate-page", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        pageType: "orchestration",
+        requirements: orchestration.description,
+        features: orchestration.workflows.join(", "),
+      }),
+    });
+
+    if (!pageResponse.ok) {
+      throw new Error(`Page generation failed: ${pageResponse.statusText}`);
+    }
+
+    const pageData = await pageResponse.json();
+    const postProcessing = await PostProcessingValidator.validateAndFixGeneratedCode(
+      pageData.page,
+      "page"
+    );
+
+    return { ...pageData, page: postProcessing.fixedCode, validation: postProcessing };
+  }
+
+  static async validateCompleteOrchestration(generatedOrchestration) {
+    const errors = [];
+    if (!generatedOrchestration.orchestration.agents || generatedOrchestration.orchestration.agents.length === 0) {
+      errors.push("Orchestration must have agents");
+    }
+    for (const agent of generatedOrchestration.agents) {
+      if (!agent.classCode || !agent.promptCode) {
+        errors.push(`Agent ${agent.id} missing required code`);
+      }
+    }
+    if (!generatedOrchestration.page.page) {
+      errors.push("Generated page is missing");
+    }
+    return { isValid: errors.length === 0, errors };
+  }
+
+  static async rollbackGeneration(generatedFiles) {
+    for (const file of generatedFiles) {
+      try {
+        await fs.unlink(file);
+      } catch (error) {
+        console.error(`Failed to rollback ${file}:`, error);
+      }
+    }
+  }
+
+  // Placeholder methods expected to be implemented elsewhere
+  static async generateOrchestration() {
+    throw new Error("generateOrchestration not implemented");
+  }
+  static async generateAgentsWithValidation() {
+    return [];
+  }
+  static async generateComponentsWithPostProcessing() {
+    return [];
+  }
+  static async saveAllFiles() {
+    return [];
+  }
+}
+
+module.exports = AutomatedGenerationPipeline;

--- a/utils/postProcessingValidator.js
+++ b/utils/postProcessingValidator.js
@@ -1,0 +1,126 @@
+class PostProcessingValidator {
+  static async validateAndFixGeneratedCode(generatedCode, type) {
+    const issues = [];
+    let fixedCode = generatedCode;
+
+    if (type === "page") {
+      const templateValidation = this.validateTemplateIntegration(generatedCode);
+      if (!templateValidation.isValid) {
+        fixedCode = this.fixTemplateIntegration(fixedCode);
+        issues.push(...templateValidation.issues);
+      }
+    }
+
+    const importValidation = this.validateImports(generatedCode);
+    if (!importValidation.isValid) {
+      fixedCode = this.fixImports(fixedCode);
+      issues.push(...importValidation.issues);
+    }
+
+    const tsValidation = this.validateTypeScriptInterfaces(generatedCode);
+    if (!tsValidation.isValid) {
+      fixedCode = this.fixTypeScriptInterfaces(fixedCode);
+      issues.push(...tsValidation.issues);
+    }
+
+    const StylingValidator = require("./stylingValidator");
+    const stylingValidation = StylingValidator.validateGeneratedCode(fixedCode);
+    if (!stylingValidation.isValid) {
+      fixedCode = this.fixStylingIssues(fixedCode);
+      issues.push(...stylingValidation.issues);
+    }
+
+    return {
+      isValid: issues.filter((issue) => issue.severity === "error").length === 0,
+      issues,
+      fixedCode,
+      appliedFixes: issues.length,
+    };
+  }
+
+  static validateTemplateIntegration(code) {
+    const issues = [];
+    if (code.includes("bg-secondary min-h-screen")) {
+      issues.push({
+        type: "template_conflict",
+        message: "Generated code contains layout that conflicts with template",
+        severity: "error",
+      });
+    }
+
+    if (!code.includes("React.FC<{ campaign: Campaign | null }>")) {
+      issues.push({
+        type: "missing_interface",
+        message: "Component missing proper template interface",
+        severity: "error",
+      });
+    }
+    return { isValid: issues.length === 0, issues };
+  }
+
+  static fixTemplateIntegration(code) {
+    code = code.replace(/bg-secondary min-h-screen/g, "");
+    code = code.replace(/max-w-7xl mx-auto px-4 py-8/g, "");
+    if (!code.includes("React.FC<{ campaign: Campaign | null }>")) {
+      code = code.replace(
+        /const \w+: React\.FC =/g,
+        "const $&: React.FC<{ campaign: Campaign | null }> = ({ campaign }) =>"
+      );
+    }
+    return code;
+  }
+
+  static validateImports(code) {
+    const issues = [];
+    if (code.includes("Campaign") && !code.includes("import")) {
+      issues.push({
+        type: "missing_import",
+        message: "Missing Campaign type import",
+        severity: "error",
+      });
+    }
+    return { isValid: issues.length === 0, issues };
+  }
+
+  static fixImports(code) {
+    if (code.includes("Campaign") && !code.includes("import")) {
+      const importStatement = "import { Campaign } from '../../types';";
+      code = importStatement + "\n" + code;
+    }
+    return code;
+  }
+
+  static validateTypeScriptInterfaces(code) {
+    const issues = [];
+    if (!code.includes("React.FC") && !code.includes("interface")) {
+      issues.push({
+        type: "missing_typescript",
+        message: "Component missing TypeScript interfaces",
+        severity: "warning",
+      });
+    }
+    return { isValid: issues.length === 0, issues };
+  }
+
+  static fixTypeScriptInterfaces(code) {
+    if (!code.includes("React.FC") && !code.includes("interface")) {
+      code = code.replace(/const (\w+) =/g, "const $1: React.FC =");
+    }
+    return code;
+  }
+
+  static fixStylingIssues(code) {
+    const StylingValidator = require("./stylingValidator");
+    const fixes = StylingValidator.suggestFixes(code);
+    fixes.forEach((fix) => {
+      if (fix.original) {
+        fix.original.forEach((o) => {
+          code = code.replace(new RegExp(o, "g"), fix.suggestion);
+        });
+      }
+    });
+    return code;
+  }
+}
+
+module.exports = PostProcessingValidator;


### PR DESCRIPTION
## Summary
- implement core ConfigMaintenanceManager and ConfigGenerator utilities
- stub automatedGenerationPipeline and postProcessingValidator utilities
- fix fictional agents in OrchestrationsPage
- add orchestration pipeline API route

## Testing
- `npm run lint:styles` *(fails: stylelint not found or lint errors)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687d11bf0db883258f02dbe18fbba5b7