### PR TITLE
Implement basic Hive workflow UI

### DIFF
--- a/frontend/src/components/orchestrations/HiveOrchestrationPage.tsx
+++ b/frontend/src/components/orchestrations/HiveOrchestrationPage.tsx
@@ -1,121 +1,118 @@
-import React from "react";
-import OrchestrationPageTemplate from "./OrchestrationPageTemplate";
-import { Campaign } from "../../types";
+import { useState } from 'react';
+import SharedOrchestrationLayout from './SharedOrchestrationLayout';
+import SidePanel from '../SidePanel';
+import { SharedDeliverablePanel } from '../shared';
+import HiveMomentForm from '../shared/HiveMomentForm';
+import HiveAgentCollaboration from '../shared/HiveAgentCollaboration';
+import { useHiveWorkflowState } from '../../hooks/useHiveWorkflowState';
+import DeliverableModal from '../DeliverableModal';
+import { Deliverable } from '../../types';
 
-// Interfaces
-interface AgentStatus {
-  name: string;
-  status: "idle" | "running" | "completed" | "error";
-}
-
-interface HiveOrchestratorProps {
-  orchestrationId: string;
+interface HiveOrchestrationPageProps {
   hitlReview?: boolean;
   onToggleHitl?: () => void;
+  onNavigateToOrchestrations?: () => void;
 }
 
-// Sample agent data
-const agents: AgentStatus[] = [
-  { name: "Trend Cultural Analyzer", status: "idle" },
-  { name: "Brand Lens", status: "idle" },
-  { name: "Visual Prompt Generator", status: "idle" },
-  { name: "Modular Elements Recommender", status: "idle" },
-  { name: "Brand QA", status: "idle" },
-];
-
-// Hive Orchestrator Component (for renderExtraCenter)
-const HiveOrchestrator: React.FC<{ campaign: Campaign | null }> = () => {
-  return (
-    <div className="space-y-6">
-      <section className="bg-white rounded-lg shadow-md p-6 border border-border">
-        <h2 className="text-xl font-bold text-text-primary mb-4">
-          Agent Status Monitoring
-        </h2>
-        <ul className="space-y-4">
-          {agents.map((agent) => (
-            <li
-              key={agent.name}
-              className={`p-4 rounded-lg border border-border ${
-                agent.status === "running"
-                  ? "bg-primary text-white"
-                  : agent.status === "completed"
-                  ? "bg-success text-white"
-                  : "bg-bg-primary text-text-secondary"
-              }`}
-            >
-              <span className="font-medium">{agent.name}</span>: {agent.status}
-            </li>
-          ))}
-        </ul>
-      </section>
-
-      <section className="bg-white rounded-lg shadow-md p-6 border border-border">
-        <h2 className="text-xl font-bold text-text-primary mb-4">
-          Workflow Visualization
-        </h2>
-        <ol className="list-decimal list-inside space-y-2 text-text-secondary">
-          <li>Trend Cultural Analysis</li>
-          <li>Brand Lens Application</li>
-          <li>Visual Prompt Generation</li>
-          <li>Modular Elements Recommendation</li>
-          <li>Brand Quality Assurance</li>
-        </ol>
-      </section>
-
-      <section className="bg-white rounded-lg shadow-md p-6 border border-border">
-        <h2 className="text-xl font-bold text-text-primary mb-4">
-          Configuration Options
-        </h2>
-        <div className="text-text-secondary">
-          <p>
-            Configure each agent's parameters to tailor the orchestration
-            process.
-          </p>
-          {/* Configuration options would be implemented here */}
-        </div>
-      </section>
-
-      <section className="bg-white rounded-lg shadow-md p-6 border border-border">
-        <h2 className="text-xl font-bold text-text-primary mb-4">
-          Execution Controls
-        </h2>
-        <button
-          className="px-4 py-2 bg-primary hover:bg-primary-hover text-white rounded transition-colors font-medium focus:ring-2 focus:ring-primary focus:border-primary"
-          aria-label="Start Orchestration"
-        >
-          Start Orchestration
-        </button>
-      </section>
-
-      <section className="bg-white rounded-lg shadow-md p-6 border border-border">
-        <h2 className="text-xl font-bold text-text-primary mb-4">
-          Results Display
-        </h2>
-        <div className="text-text-secondary">
-          <p>
-            View the results of the orchestration process here once completed.
-          </p>
-          {/* Results display would be implemented here */}
-        </div>
-      </section>
-    </div>
-  );
-};
-
-// Main Hive Orchestration Page
-const HiveOrchestrationPage: React.FC<HiveOrchestratorProps> = ({
-  orchestrationId,
+const HiveOrchestrationPage: React.FC<HiveOrchestrationPageProps> = ({
   hitlReview = true,
   onToggleHitl,
+  onNavigateToOrchestrations,
 }) => {
+  const { workflow, isLoading, startOrchestration, resetWorkflow } = useHiveWorkflowState();
+  const [isSidePanelOpen, setIsSidePanelOpen] = useState(false);
+  const [modalDeliverable, setModalDeliverable] = useState<Deliverable | null>(null);
+  const [isDeliverableModalOpen, setIsDeliverableModalOpen] = useState(false);
+
+  const handleStart = async (context: any) => {
+    await startOrchestration(context);
+  };
+
+  const deliverables = workflow ? Object.values(workflow.deliverables) : [];
+
   return (
-    <OrchestrationPageTemplate
-      orchestrationId={orchestrationId}
-      orchestrationName="Hive Orchestrator"
-      hitlReview={hitlReview}
-      onToggleHitl={onToggleHitl}
-      renderExtraCenter={(campaign) => <HiveOrchestrator campaign={campaign} />}
-    />
+    <div className="min-h-screen">
+      <div className="container pt-6 pb-8">
+        <div className="mb-6 flex items-center justify-between">
+          <nav className="flex items-center space-x-2 text-sm text-text-secondary">
+            <button
+              onClick={onNavigateToOrchestrations || (() => window.history.back())}
+              className="text-success hover:text-success-hover transition-colors"
+            >
+              Orchestrations
+            </button>
+            <span>›</span>
+            <span className="text-text-primary font-medium">Hive Orchestrator</span>
+          </nav>
+          {onToggleHitl && (
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-text-secondary">HITL Review</span>
+              <button
+                onClick={onToggleHitl}
+                className={`relative inline-flex h-6 w-12 items-center rounded-full ${
+                  hitlReview ? 'bg-success' : 'bg-secondary'
+                }`}
+              >
+                <span
+                  className={`inline-block h-4 w-4 transform rounded-full bg-white ${
+                    hitlReview ? 'translate-x-7' : 'translate-x-1'
+                  }`}
+                />
+                <span
+                  className={`absolute text-xs font-medium ${
+                    hitlReview ? 'text-white left-1' : 'text-text-secondary right-1'
+                  }`}
+                >
+                  {hitlReview ? 'ON' : 'OFF'}
+                </span>
+              </button>
+            </div>
+          )}
+        </div>
+        <SharedOrchestrationLayout
+          isSidePanelOpen={isSidePanelOpen}
+          sidePanel={
+            <SidePanel
+              messages={[]}
+              isOpen={isSidePanelOpen}
+              onClose={() => setIsSidePanelOpen(false)}
+            />
+          }
+          rightPanel={
+            <SharedDeliverablePanel
+              deliverables={deliverables}
+              onViewDetails={(id) => {
+                const d = deliverables.find((x) => x.id === id);
+                if (d) {
+                  setModalDeliverable(d);
+                  setIsDeliverableModalOpen(true);
+                }
+              }}
+            />
+          }
+        >
+          {!workflow ? (
+            <HiveMomentForm onSubmit={handleStart} onCancel={resetWorkflow} isLoading={isLoading} />
+          ) : (
+            <HiveAgentCollaboration
+              workflow={workflow}
+              onViewDeliverable={(phase) => {
+                const d = workflow.deliverables[phase];
+                if (d) {
+                  setModalDeliverable(d);
+                  setIsDeliverableModalOpen(true);
+                }
+              }}
+            />
+          )}
+        </SharedOrchestrationLayout>
+      </div>
+      <DeliverableModal
+        deliverable={modalDeliverable}
+        isOpen={isDeliverableModalOpen}
+        onClose={() => setIsDeliverableModalOpen(false)}
+      />
+    </div>
   );
 };
 

--- a/frontend/src/components/shared/HiveAgentCollaboration.tsx
+++ b/frontend/src/components/shared/HiveAgentCollaboration.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { HiveWorkflowState } from '../../types';
+import { CheckCircle } from 'lucide-react';
+
+interface HiveAgentCollaborationProps {
+  workflow: HiveWorkflowState;
+  onViewDeliverable?: (phaseKey: string) => void;
+}
+
+const phases = [
+  { key: 'trend_analysis', label: 'Trend Analysis', icon: '📈' },
+  { key: 'visual_prompt', label: 'Visual Prompt', icon: '🎨' },
+  { key: 'modular_elements', label: 'Modular Elements', icon: '🧩' },
+  { key: 'qa_review', label: 'Quality Review', icon: '✅' },
+];
+
+const HiveAgentCollaboration: React.FC<HiveAgentCollaborationProps> = ({ workflow, onViewDeliverable }) => {
+  return (
+    <div className="bg-white rounded-lg shadow-md">
+      <div className="p-4 border-b border-border">
+        <h2 className="text-xl font-bold text-text-primary">Hive Workflow</h2>
+      </div>
+      <div className="p-6 space-y-4">
+        {phases.map((phase) => {
+          const deliverable = workflow.deliverables[phase.key];
+          const completed = Boolean(deliverable);
+          return (
+            <div key={phase.key} className="p-4 border rounded-lg flex items-center gap-3">
+              <div className="text-lg">{phase.icon}</div>
+              <div className="flex-1">
+                <span className="font-medium text-text-primary">{phase.label}</span>
+              </div>
+              {completed && <CheckCircle size={16} className="text-success" />}
+              {completed && onViewDeliverable && (
+                <button
+                  onClick={() => onViewDeliverable(phase.key)}
+                  className="ml-3 text-sm text-primary underline"
+                >
+                  View
+                </button>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default HiveAgentCollaboration;

--- a/frontend/src/components/shared/HiveMomentForm.tsx
+++ b/frontend/src/components/shared/HiveMomentForm.tsx
@@ -1,0 +1,111 @@
+import React, { useState } from 'react';
+
+export interface HiveMomentFormProps {
+  onSubmit: (context: any) => void;
+  isLoading: boolean;
+  onCancel: () => void;
+}
+
+const HiveMomentForm: React.FC<HiveMomentFormProps> = ({ onSubmit, isLoading, onCancel }) => {
+  const [context, setContext] = useState({
+    campaign: '',
+    momentType: 'campaign',
+    visualObjective: '',
+    heroVisualDescription: '',
+    promptSnippet: '',
+    modularElements: [] as string[],
+  });
+
+  const handleChange = (field: string, value: any) => {
+    setContext((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (context.campaign.trim()) {
+      onSubmit(context);
+    }
+  };
+
+  return (
+    <div className="bg-white rounded-lg shadow-md p-6">
+      <h2 className="text-2xl font-bold text-text-primary mb-4">Start Hive Orchestration</h2>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label htmlFor="campaign" className="block text-sm font-medium text-text-secondary mb-1">
+            Campaign / Moment Context
+          </label>
+          <textarea
+            id="campaign"
+            value={context.campaign}
+            onChange={(e) => handleChange('campaign', e.target.value)}
+            className="w-full h-24 p-3 border border-border rounded-md"
+            disabled={isLoading}
+            required
+          />
+        </div>
+        <div>
+          <label htmlFor="momentType" className="block text-sm font-medium text-text-secondary mb-1">
+            Moment Type
+          </label>
+          <select
+            id="momentType"
+            value={context.momentType}
+            onChange={(e) => handleChange('momentType', e.target.value)}
+            className="w-full p-3 border border-border rounded-md"
+            disabled={isLoading}
+          >
+            <option value="campaign">Campaign</option>
+            <option value="launch">Launch</option>
+            <option value="event">Event</option>
+            <option value="promotion">Promotion</option>
+            <option value="seasonal">Seasonal</option>
+          </select>
+        </div>
+        <div>
+          <label htmlFor="visualObjective" className="block text-sm font-medium text-text-secondary mb-1">
+            Visual Objective
+          </label>
+          <textarea
+            id="visualObjective"
+            value={context.visualObjective}
+            onChange={(e) => handleChange('visualObjective', e.target.value)}
+            className="w-full h-24 p-3 border border-border rounded-md"
+            disabled={isLoading}
+          />
+        </div>
+        <div>
+          <label htmlFor="heroVisualDescription" className="block text-sm font-medium text-text-secondary mb-1">
+            Hero Visual Description
+          </label>
+          <textarea
+            id="heroVisualDescription"
+            value={context.heroVisualDescription}
+            onChange={(e) => handleChange('heroVisualDescription', e.target.value)}
+            className="w-full h-24 p-3 border border-border rounded-md"
+            disabled={isLoading}
+          />
+        </div>
+        <div className="flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-4 py-2 bg-secondary text-text-primary rounded-md"
+            disabled={isLoading}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="px-4 py-2 bg-primary text-white rounded-md"
+            disabled={isLoading || !context.campaign.trim()}
+          >
+            {isLoading ? 'Starting...' : 'Start Orchestration'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default HiveMomentForm;

--- a/frontend/src/components/shared/ImageDeliverableCard.tsx
+++ b/frontend/src/components/shared/ImageDeliverableCard.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Deliverable } from '../../types';
+import { Eye } from 'lucide-react';
+
+interface ImageDeliverableCardProps {
+  deliverable: Deliverable;
+  onViewDetails: (id: string) => void;
+}
+
+const ImageDeliverableCard: React.FC<ImageDeliverableCardProps> = ({ deliverable, onViewDetails }) => {
+  const hasImage = typeof deliverable.content === 'object' && (deliverable.content as any).imageUrl;
+  const imageUrl = hasImage ? (deliverable.content as any).imageUrl : null;
+
+  return (
+    <div
+      className="deliverable-card flex flex-col gap-2 cursor-pointer hover:shadow-md transition-shadow"
+      onClick={() => onViewDetails(deliverable.id)}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <span className="deliverable-icon text-2xl">🖼️</span>
+            <h3 className="deliverable-title-text text-lg font-semibold truncate" title={deliverable.title}>
+              {deliverable.title}
+            </h3>
+          </div>
+          <div className="text-sm text-gray-500 truncate" title={deliverable.agent}>
+            {deliverable.agent}
+          </div>
+        </div>
+        <button
+          className="deliverable-icon-btn"
+          onClick={(e) => {
+            e.stopPropagation();
+            onViewDetails(deliverable.id);
+          }}
+          title="View Details"
+          aria-label="View Details"
+        >
+          <Eye size={18} />
+        </button>
+      </div>
+      {imageUrl && (
+        <img src={imageUrl} alt={deliverable.title} className="w-full h-32 object-cover rounded-lg border border-border" />
+      )}
+    </div>
+  );
+};
+
+export default ImageDeliverableCard;

--- a/frontend/src/components/shared/SharedDeliverablePanel.tsx
+++ b/frontend/src/components/shared/SharedDeliverablePanel.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Deliverable } from '../../types';
 import SharedDeliverableCard from './SharedDeliverableCard';
+import ImageDeliverableCard from './ImageDeliverableCard';
 import { FileText } from 'lucide-react';
 import './sharedStyles.css';
 
@@ -33,9 +34,14 @@ const SharedDeliverablePanel: React.FC<SharedDeliverablePanelProps> = ({ deliver
       </div>
     ) : (
       <div className="space-y-4">
-        {deliverables.map((d) => (
-          <SharedDeliverableCard key={d.id} deliverable={d} onViewDetails={onViewDetails} />
-        ))}
+        {deliverables.map((d) => {
+          const hasImage = typeof d.content === 'object' && (d.content as any).imageUrl;
+          return hasImage ? (
+            <ImageDeliverableCard key={d.id} deliverable={d} onViewDetails={onViewDetails} />
+          ) : (
+            <SharedDeliverableCard key={d.id} deliverable={d} onViewDetails={onViewDetails} />
+          );
+        })}
       </div>
     )}
   </div>

--- a/frontend/src/components/shared/index.ts
+++ b/frontend/src/components/shared/index.ts
@@ -7,3 +7,6 @@ export { default as SharedHitlToggle } from './SharedHitlToggle';
 export { default as SharedActionButtons } from './SharedActionButtons';
 export { default as SharedModal } from './SharedModal';
 export { default as SharedAgentCollaboration } from './SharedAgentCollaboration';
+export { default as HiveMomentForm } from './HiveMomentForm';
+export { default as HiveAgentCollaboration } from './HiveAgentCollaboration';
+export { default as ImageDeliverableCard } from './ImageDeliverableCard';

--- a/frontend/src/hooks/useHiveWorkflowState.ts
+++ b/frontend/src/hooks/useHiveWorkflowState.ts
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+import { apiFetch } from '../utils/api';
+import { HiveWorkflowState, Deliverable } from '../types';
+
+export function useHiveWorkflowState() {
+  const [workflow, setWorkflow] = useState<HiveWorkflowState | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const startOrchestration = async (context: any) => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const data = await apiFetch('/api/hive-orchestrate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(context),
+      });
+
+      const deliverables: { [k: string]: Deliverable } = {
+        trend_analysis: {
+          id: 'trend_analysis',
+          title: 'Trend Insights',
+          status: 'ready',
+          agent: 'Trend Cultural Analyzer',
+          timestamp: new Date().toISOString(),
+          content: data.trendInsights,
+        },
+        visual_prompt: {
+          id: 'visual_prompt',
+          title: 'Visual Prompt',
+          status: 'ready',
+          agent: 'Visual Prompt Generator',
+          timestamp: new Date().toISOString(),
+          content: { promptText: data.promptText, imageUrl: data.imageUrl },
+        },
+        modular_elements: {
+          id: 'modular_elements',
+          title: 'Modular Elements',
+          status: 'ready',
+          agent: 'Modular Elements Recommender',
+          timestamp: new Date().toISOString(),
+          content: { elements: data.modulars },
+        },
+        qa_review: {
+          id: 'qa_review',
+          title: 'QA Review',
+          status: 'ready',
+          agent: 'Brand QA',
+          timestamp: new Date().toISOString(),
+          content: data.qaResult,
+        },
+      };
+
+      const wf: HiveWorkflowState = {
+        id: Date.now().toString(),
+        status: 'completed',
+        deliverables,
+        createdAt: new Date().toISOString(),
+        lastUpdated: new Date().toISOString(),
+      };
+
+      setWorkflow(wf);
+      return wf;
+    } catch (e: any) {
+      setError(e.message);
+      throw e;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const resetWorkflow = () => setWorkflow(null);
+
+  return { workflow, isLoading, error, startOrchestration, resetWorkflow };
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -99,3 +99,12 @@ export interface AudienceResearch {
     tertiary: string;
   };
 }
+
+export interface HiveWorkflowState {
+  id: string;
+  status: 'running' | 'completed' | 'failed';
+  deliverables: { [key: string]: Deliverable };
+  createdAt?: string;
+  lastUpdated?: string;
+  error?: string;
+}


### PR DESCRIPTION
## Summary
- add HiveWorkflowState type and workflow hook
- implement Hive form and agent collaboration components
- handle image deliverables in panel
- update shared exports
- rewrite HiveOrchestrationPage to use shared layout

## Testing
- `npm run lint:styles` *(fails: 345 errors)*

------
https://chatgpt.com/codex/tasks/task_b_687d41dea1d88325a0e510e2f443979a