### PR TITLE
Finalize Hive image deliverables

### DIFF
--- a/frontend/src/components/DeliverableModal.tsx
+++ b/frontend/src/components/DeliverableModal.tsx
@@ -22,6 +22,23 @@ const DeliverableModal: React.FC<DeliverableModalProps> = ({
   if (!isOpen || !deliverable) return null;
 
   const handleDownload = () => {
+    const imageUrl =
+      deliverable.type === "image" &&
+      typeof deliverable.content === "object" &&
+      (deliverable.content as any).imageUrl
+        ? (deliverable.content as any).imageUrl
+        : null;
+
+    if (imageUrl) {
+      const a = document.createElement("a");
+      a.href = imageUrl;
+      a.download = `${deliverable.title.replace(/\s+/g, "_")}.png`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      return;
+    }
+
     const content =
       typeof deliverable.content === "string"
         ? deliverable.content
@@ -55,7 +72,16 @@ const DeliverableModal: React.FC<DeliverableModalProps> = ({
           </button>
         </div>
 
-        <div className="deliverable-modal-body">
+        <div className="deliverable-modal-body space-y-4">
+          {deliverable.type === 'image' &&
+          typeof deliverable.content === 'object' &&
+          (deliverable.content as any).imageUrl ? (
+            <img
+              src={(deliverable.content as any).imageUrl}
+              alt={deliverable.title}
+              className="w-full h-auto object-contain rounded-md border border-border"
+            />
+          ) : null}
           <DeliverableContent content={deliverable.content} />
         </div>
 

--- a/frontend/src/components/shared/ImageDeliverableCard.tsx
+++ b/frontend/src/components/shared/ImageDeliverableCard.tsx
@@ -1,15 +1,33 @@
 import React from 'react';
 import { Deliverable } from '../../types';
-import { Eye } from 'lucide-react';
+import { Eye, Download } from 'lucide-react';
 
 interface ImageDeliverableCardProps {
   deliverable: Deliverable;
   onViewDetails: (id: string) => void;
 }
 
-const ImageDeliverableCard: React.FC<ImageDeliverableCardProps> = ({ deliverable, onViewDetails }) => {
-  const hasImage = typeof deliverable.content === 'object' && (deliverable.content as any).imageUrl;
-  const imageUrl = hasImage ? (deliverable.content as any).imageUrl : null;
+const ImageDeliverableCard: React.FC<ImageDeliverableCardProps> = ({
+  deliverable,
+  onViewDetails,
+}) => {
+  const content =
+    typeof deliverable.content === 'object' ? (deliverable.content as any) : null;
+  let imageUrl: string | null = content?.imageUrl || null;
+  if (imageUrl && !imageUrl.startsWith('data:image')) {
+    imageUrl = `data:image/png;base64,${imageUrl}`;
+  }
+
+  const handleDownload = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!imageUrl) return;
+    const a = document.createElement('a');
+    a.href = imageUrl;
+    a.download = `${deliverable.title.replace(/\s+/g, '_')}.png`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  };
 
   return (
     <div
@@ -28,20 +46,34 @@ const ImageDeliverableCard: React.FC<ImageDeliverableCardProps> = ({ deliverable
             {deliverable.agent}
           </div>
         </div>
-        <button
-          className="deliverable-icon-btn"
-          onClick={(e) => {
-            e.stopPropagation();
-            onViewDetails(deliverable.id);
-          }}
-          title="View Details"
-          aria-label="View Details"
-        >
-          <Eye size={18} />
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            className="deliverable-icon-btn"
+            onClick={handleDownload}
+            title="Download Image"
+            aria-label="Download Image"
+          >
+            <Download size={18} />
+          </button>
+          <button
+            className="deliverable-icon-btn"
+            onClick={(e) => {
+              e.stopPropagation();
+              onViewDetails(deliverable.id);
+            }}
+            title="View Details"
+            aria-label="View Details"
+          >
+            <Eye size={18} />
+          </button>
+        </div>
       </div>
       {imageUrl && (
-        <img src={imageUrl} alt={deliverable.title} className="w-full h-32 object-cover rounded-lg border border-border" />
+        <img
+          src={imageUrl}
+          alt={deliverable.title}
+          className="w-full h-48 object-contain rounded-lg border border-border"
+        />
       )}
     </div>
   );

--- a/frontend/src/components/shared/SharedDeliverablePanel.tsx
+++ b/frontend/src/components/shared/SharedDeliverablePanel.tsx
@@ -15,6 +15,9 @@ export interface SharedDeliverablePanelProps {
   onViewDetails: (id: string) => void;
 }
 
+const isImageDeliverable = (d: Deliverable) =>
+  d.type === 'image' || (typeof d.content === 'object' && (d.content as any).imageUrl);
+
 const SharedDeliverablePanel: React.FC<SharedDeliverablePanelProps> = ({ deliverables, onViewDetails }) => (
   <div className="deliverable-card">
     <div className="deliverable-header">
@@ -34,14 +37,13 @@ const SharedDeliverablePanel: React.FC<SharedDeliverablePanelProps> = ({ deliver
       </div>
     ) : (
       <div className="space-y-4">
-        {deliverables.map((d) => {
-          const hasImage = typeof d.content === 'object' && (d.content as any).imageUrl;
-          return hasImage ? (
+        {deliverables.map((d) =>
+          isImageDeliverable(d) ? (
             <ImageDeliverableCard key={d.id} deliverable={d} onViewDetails={onViewDetails} />
           ) : (
             <SharedDeliverableCard key={d.id} deliverable={d} onViewDetails={onViewDetails} />
-          );
-        })}
+          )
+        )}
       </div>
     )}
   </div>


### PR DESCRIPTION
## Summary
- improve ImageDeliverableCard to show and download OpenAI images
- route image deliverables properly with SharedDeliverablePanel
- show images in DeliverableModal with download support

## Testing
- `npm run lint:styles` *(fails: many style issues)*

------
https://chatgpt.com/codex/tasks/task_b_687d4892814c8325a5130694475ad9b5