### PR TITLE
Fix duplicate empty research deliverables

### DIFF
--- a/frontend/src/utils/campaignUtils.ts
+++ b/frontend/src/utils/campaignUtils.ts
@@ -3,16 +3,36 @@ import { Deliverable } from '../types';
 export function extractDeliverables(data: any): { [key: string]: Deliverable } {
   const extracted: { [key: string]: Deliverable } = {};
 
+  const addDeliverable = (key: string, deliverable: Deliverable) => {
+    const content = deliverable.content;
+    const isEmpty =
+      !content ||
+      (typeof content === 'string' && content.trim() === '') ||
+      (typeof content === 'object' &&
+        Object.values(content).every((v) =>
+          typeof v === 'string' ? v.trim() === '' || v.trim() === 'N/A' : false
+        ));
+    if (isEmpty) return;
+
+    const exists = Object.values(extracted).some(
+      (d) => JSON.stringify(d.content) === JSON.stringify(content)
+    );
+    if (!exists && !extracted[key]) {
+      extracted[key] = deliverable;
+    }
+  };
+
   if (data.phases?.research?.insights) {
-    extracted['research'] = {
+    addDeliverable('research', {
       id: 'research',
       title: 'Audience Research',
       status: 'completed',
       agent: 'Research & Audience GPT',
-      timestamp: data.phases.research.insights.lastUpdated || new Date().toISOString(),
+      timestamp:
+        data.phases.research.insights.lastUpdated || new Date().toISOString(),
       content: data.phases.research.insights.analysis,
       lastUpdated: data.phases.research.insights.lastUpdated,
-    };
+    });
   }
 
   if (data.conversation) {
@@ -20,7 +40,7 @@ export function extractDeliverables(data: any): { [key: string]: Deliverable } {
       if (msg.deliverable) {
         const agentName = msg.agent || msg.speaker || 'AI Agent';
         const key = agentName.toLowerCase().replace(/\s+/g, '-');
-        extracted[key] = {
+        addDeliverable(key, {
           id: key,
           title: `${agentName} Analysis`,
           status: 'completed',
@@ -28,7 +48,7 @@ export function extractDeliverables(data: any): { [key: string]: Deliverable } {
           timestamp: msg.timestamp || new Date().toISOString(),
           content: msg.deliverable.analysis || msg.deliverable,
           lastUpdated: msg.timestamp,
-        };
+        });
       }
     });
   }


### PR DESCRIPTION
## Summary
- filter deliverables before adding to prevent duplicates and ignore empty data

## Testing
- `npm run lint:styles` *(fails: many stylelint errors)*

------
https://chatgpt.com/codex/tasks/task_b_687f6096fec483258797af2511d62ad5