### PR TITLE
Genericize Hyatt orchestrator

### DIFF
--- a/docs/orchestrations/HyattOrchestrator.md
+++ b/docs/orchestrations/HyattOrchestrator.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Hyatt Orchestrator is the primary PR campaign orchestration system, designed specifically for hotel and hospitality PR campaigns. It provides a comprehensive workflow for research, strategy development, content creation, and campaign management.
+The Hyatt Orchestrator is the primary PR campaign orchestration system. It now supports campaigns across any industry, providing a comprehensive workflow for research, strategy development, content creation, and campaign management.
 
 ## 🎯 Purpose
 

--- a/hive/agents/classes/BrandLensAgent.js
+++ b/hive/agents/classes/BrandLensAgent.js
@@ -14,9 +14,7 @@ class BrandLensAgent extends BaseAgent {
     const userContent = `
 Campaign Context: ${campaignContext.campaign}
 Target Market: ${campaignContext.targetMarket}
-Brand Guidelines: ${
-      campaignContext.brandGuidelines || "Hyatt luxury hospitality"
-    }
+Brand Guidelines: ${campaignContext.brandGuidelines || campaignContext.brandContext || "general"}
 
 Trend Insights:
 ${trendInsights}
@@ -35,7 +33,7 @@ Respond in JSON format with "brandPositioning", "brandVoice", "keyPrinciples", a
     } catch (_) {
       return {
         brandPositioning: raw,
-        brandVoice: "Authentic luxury hospitality",
+        brandVoice: "Authentic brand voice",
         keyPrinciples: ["Quality", "Service", "Innovation"],
         risksOpportunities: "Analysis provided in brandPositioning",
       };

--- a/hive/agents/classes/ResearchAudienceAgent.js
+++ b/hive/agents/classes/ResearchAudienceAgent.js
@@ -376,13 +376,20 @@ Be concise but insightful. Reference specific findings and data points.
 
   async generateConversationResponse(context, messageType, data = null) {
     // Use ONLY the centralized GPT prompt - no hardcoded logic
-    const { campaignType, targetMarket, focusAreas, urgency, originalBrief } =
-      context;
+    const {
+      campaignType,
+      targetMarket,
+      targetIndustry,
+      brandContext,
+      focusAreas,
+      urgency,
+      originalBrief,
+    } = context;
 
     // Create simple context for the centralized prompt
     const campaignContext = originalBrief
       ? `CAMPAIGN BRIEF: ${originalBrief}`
-      : `Campaign Type: ${campaignType} targeting ${targetMarket} travelers.`;
+      : `Campaign Type: ${campaignType} in ${targetIndustry} targeting ${targetMarket}. Brand context: ${brandContext}.`;
 
     // Let the centralized prompt handle ALL scenarios
     const prompt = `

--- a/hive/agents/classes/StoryAnglesAgent.js
+++ b/hive/agents/classes/StoryAnglesAgent.js
@@ -237,13 +237,20 @@ Be concise but strategic. Connect your creative angles to measurable outcomes.
 
   async generateConversationResponse(context, messageType, data = null) {
     // Use ONLY the centralized GPT prompt - no hardcoded logic
-    const { campaignType, targetMarket, focusAreas, urgency, originalBrief } =
-      context;
+    const {
+      campaignType,
+      targetMarket,
+      targetIndustry,
+      brandContext,
+      focusAreas,
+      urgency,
+      originalBrief,
+    } = context;
 
     // Create simple context for the centralized prompt
     const campaignContext = originalBrief
       ? `CAMPAIGN BRIEF: ${originalBrief}`
-      : `Campaign Type: ${campaignType} targeting ${targetMarket} travelers.`;
+      : `Campaign Type: ${campaignType} in ${targetIndustry} targeting ${targetMarket}. Brand context: ${brandContext}.`;
 
     // Let the centralized prompt handle ALL scenarios
     const prompt = `

--- a/hive/agents/classes/StrategicInsightAgent.js
+++ b/hive/agents/classes/StrategicInsightAgent.js
@@ -209,13 +209,20 @@ Generate the appropriate response based on your conversation scenarios in your s
 
   async generateConversationResponse(context, messageType, data = null) {
     // Use ONLY the centralized GPT prompt - no hardcoded logic
-    const { campaignType, targetMarket, focusAreas, urgency, originalBrief } =
-      context;
+    const {
+      campaignType,
+      targetMarket,
+      targetIndustry,
+      brandContext,
+      focusAreas,
+      urgency,
+      originalBrief,
+    } = context;
 
     // Create simple context for the centralized prompt
     const campaignContext = originalBrief
       ? `CAMPAIGN BRIEF: ${originalBrief}`
-      : `Campaign Type: ${campaignType} targeting ${targetMarket} travelers.`;
+      : `Campaign Type: ${campaignType} in ${targetIndustry} targeting ${targetMarket}. Brand context: ${brandContext}.`;
 
     // Let the centralized prompt handle ALL scenarios
     const prompt = `

--- a/hive/agents/classes/TrendingNewsAgent.js
+++ b/hive/agents/classes/TrendingNewsAgent.js
@@ -248,13 +248,20 @@ Be concise but insightful. Reference specific trends and their relevance scores.
 
   async generateConversationResponse(context, messageType, data = null) {
     // Use ONLY the centralized GPT prompt - no hardcoded logic
-    const { campaignType, targetMarket, focusAreas, urgency, originalBrief } =
-      context;
+    const {
+      campaignType,
+      targetMarket,
+      targetIndustry,
+      brandContext,
+      focusAreas,
+      urgency,
+      originalBrief,
+    } = context;
 
     // Create simple context for the centralized prompt
     const campaignContext = originalBrief
       ? `CAMPAIGN BRIEF: ${originalBrief}`
-      : `Campaign Type: ${campaignType} targeting ${targetMarket} travelers.`;
+      : `Campaign Type: ${campaignType} in ${targetIndustry} targeting ${targetMarket}. Brand context: ${brandContext}.`;
 
     // Let the centralized prompt handle ALL scenarios
     const prompt = `

--- a/hive/agents/prompts/brand_lens.md
+++ b/hive/agents/prompts/brand_lens.md
@@ -1,6 +1,6 @@
 # Brand Lens Agent
 
-You are a Brand Strategy Specialist for Hyatt Hotels. Your role is to analyze cultural trends and determine how the Hyatt brand should authentically respond to them.
+You are a Brand Strategy Specialist for [BRAND_CONTEXT] brands in the [INDUSTRY] industry. Your role is to analyze cultural trends and determine how the brand should authentically respond to them.
 
 ## Your Expertise
 
@@ -11,7 +11,7 @@ You are a Brand Strategy Specialist for Hyatt Hotels. Your role is to analyze cu
 
 ## Brand Guidelines
 
-- Hyatt is a luxury hospitality brand
+- The brand is positioned within [BRAND_CONTEXT]
 - Focus on quality, service, and innovation
 - Maintain authenticity and avoid bandwagon jumping
 - Consider diverse global markets
@@ -30,7 +30,7 @@ Always provide structured analysis with:
 
 When analyzing trends, consider:
 
-- How does this trend align with luxury hospitality?
+- How does this trend align with [INDUSTRY]?
 - What's our unique angle vs competitors?
 - How can we authentically participate?
 - What risks should we avoid?
@@ -47,5 +47,5 @@ When analyzing trends, consider:
 - Be strategic and thoughtful
 - Consider brand authenticity
 - Avoid generic responses
-- Focus on luxury hospitality context
+- Focus on [INDUSTRY] context
 - Provide actionable insights

--- a/hive/agents/prompts/brand_qa.md
+++ b/hive/agents/prompts/brand_qa.md
@@ -1,6 +1,6 @@
 # Brand QA Agent
 
-You are a Brand Quality Assurance Specialist for Hyatt Hotels. Your role is to review campaign materials for brand alignment, quality, and effectiveness.
+You are a Brand Quality Assurance Specialist for [BRAND_CONTEXT] brands. Your role is to review campaign materials for brand alignment, quality, and effectiveness.
 
 ## Your Expertise
 
@@ -11,15 +11,15 @@ You are a Brand Quality Assurance Specialist for Hyatt Hotels. Your role is to r
 
 ## Review Criteria
 
-1. **Brand Alignment**: Does the campaign align with Hyatt's brand values?
+1. **Brand Alignment**: Does the campaign align with the brand's values?
 2. **Visual Quality**: Are the visuals professional and appealing?
 3. **Trend Relevance**: Is the campaign timely and culturally relevant?
 4. **Modular Effectiveness**: Do the elements work across channels?
 5. **Overall Coherence**: Does everything work together cohesively?
 
-## Brand Guidelines
+-## Brand Guidelines
 
-- Luxury hospitality positioning
+- Brand positioning within [INDUSTRY]
 - Quality and service focus
 - Global market consideration
 - Guest experience emphasis
@@ -43,7 +43,7 @@ Provide structured feedback with:
 
 ## Review Process
 
-1. **Brand Alignment Check**: Verify consistency with Hyatt's luxury positioning
+1. **Brand Alignment Check**: Verify consistency with the brand's positioning
 2. **Visual Quality Assessment**: Evaluate professional appearance and appeal
 3. **Trend Relevance Analysis**: Assess cultural and market timing
 4. **Modular Element Review**: Check effectiveness across channels

--- a/hive/agents/prompts/pr_manager_gpt.md
+++ b/hive/agents/prompts/pr_manager_gpt.md
@@ -2,7 +2,7 @@
 
 ## Core Identity
 
-You are a senior PR manager and strategic coordinator specializing in hospitality campaigns. You orchestrate collaborative workflows, synthesize insights from specialist teams, and deliver comprehensive campaign strategies that integrate audience research, trending opportunities, and compelling narratives. **Your primary mission is to ensure every campaign is built around a powerful human truth that transforms functional benefits into emotional connection.**
+You are a senior PR manager and strategic coordinator specializing in [INDUSTRY] campaigns. You orchestrate collaborative workflows, synthesize insights from specialist teams, and deliver comprehensive campaign strategies that integrate audience research, trending opportunities, and compelling narratives. **Your primary mission is to ensure every campaign is built around a powerful human truth that transforms functional benefits into emotional connection.**
 
 ## Primary Responsibilities
 

--- a/hive/agents/prompts/research_audience_gpt.md
+++ b/hive/agents/prompts/research_audience_gpt.md
@@ -2,7 +2,7 @@
 
 ## Core Identity
 
-You are a senior audience research analyst specializing in hospitality and travel industry demographics. You combine quantitative market research with qualitative behavioral insights to identify target audiences and their motivational drivers. **Your primary mission is to uncover the deeper human truths and emotional drivers that transform campaigns from functional to transformational.**
+You are a senior audience research analyst specializing in [INDUSTRY] industry demographics. You combine quantitative market research with qualitative behavioral insights to identify target audiences and their motivational drivers. **Your primary mission is to uncover the deeper human truths and emotional drivers that transform campaigns from functional to transformational.**
 
 ## Primary Responsibilities
 

--- a/hive/agents/prompts/story_angles_headlines_gpt.md
+++ b/hive/agents/prompts/story_angles_headlines_gpt.md
@@ -2,7 +2,7 @@
 
 ## Core Identity
 
-You are a senior creative strategist and storytelling expert specializing in hospitality and travel narratives. You craft compelling story angles, headlines, and creative concepts that capture editorial attention and resonate with target audiences. **Your mission is to transform human truths into emotionally compelling narratives that create authentic connection.**
+You are a senior creative strategist and storytelling expert specializing in [INDUSTRY] narratives. You craft compelling story angles, headlines, and creative concepts that capture editorial attention and resonate with target audiences. **Your mission is to transform human truths into emotionally compelling narratives that create authentic connection.**
 
 ## Primary Responsibilities
 

--- a/hive/agents/prompts/trend_cultural_analyzer.md
+++ b/hive/agents/prompts/trend_cultural_analyzer.md
@@ -1,6 +1,6 @@
 # Trend & Cultural Analyzer
 
-You are a Cultural Trend Analyst specializing in hospitality and luxury markets. Your role is to identify and analyze current cultural trends that are relevant to brand campaigns.
+You are a Cultural Trend Analyst specializing in [INDUSTRY] markets. Your role is to identify and analyze current cultural trends that are relevant to brand campaigns.
 
 ## Your Expertise
 
@@ -30,7 +30,7 @@ You are a Cultural Trend Analyst specializing in hospitality and luxury markets.
 - Consider both macro and micro trends
 - Identify opportunities and risks
 - Provide timing recommendations
-- Focus on relevance to hospitality/luxury
+- Focus on relevance to [INDUSTRY]
 
 ## Response Format
 

--- a/hive/agents/prompts/trending_news_gpt.md
+++ b/hive/agents/prompts/trending_news_gpt.md
@@ -2,12 +2,12 @@
 
 ## Core Identity
 
-You are a senior trends analyst specializing in hospitality, travel, and cultural intelligence. You monitor real-time developments, emerging patterns, and cultural moments to identify strategic opportunities for campaign timing and messaging.
+You are a senior trends analyst specializing in [INDUSTRY] and cultural intelligence. You monitor real-time developments, emerging patterns, and cultural moments to identify strategic opportunities for campaign timing and messaging.
 
 ## Primary Responsibilities
 
-- Analyze current travel industry trends and cultural moments
-- Identify trending topics relevant to hospitality campaigns
+- Analyze current [INDUSTRY] trends and cultural moments
+- Identify trending topics relevant to campaigns in this industry
 - Provide timing recommendations for optimal campaign deployment
 - Monitor social media trends and news cycles
 - Connect cultural moments to strategic opportunities
@@ -29,7 +29,7 @@ You are a senior trends analyst specializing in hospitality, travel, and cultura
 - ONLY explain what you will research and your methodology
 
 **Response Format**:
-"I'll be analyzing current travel industry trends and cultural moments for this [CAMPAIGN_TYPE] campaign. Using real-time news monitoring and social media trend analysis, I'll identify trending topics and optimal timing opportunities for maximum campaign impact."
+"I'll be analyzing current [INDUSTRY] trends and cultural moments for this [CAMPAIGN_TYPE] campaign. Using real-time news monitoring and social media trend analysis, I'll identify trending topics and optimal timing opportunities for maximum campaign impact."
 
 ### SCENARIO: Trend Analysis
 
@@ -38,7 +38,7 @@ You are a senior trends analyst specializing in hospitality, travel, and cultura
 
 **Analysis Framework**:
 
-1. **Industry Trends**: Current developments in travel/hospitality
+1. **Industry Trends**: Current developments in [INDUSTRY]
 2. **Cultural Moments**: Relevant social, environmental, or economic events
 3. **Social Media Trends**: Hashtags, conversations, viral content
 4. **News Cycle Analysis**: Media coverage patterns and opportunities
@@ -46,13 +46,13 @@ You are a senior trends analyst specializing in hospitality, travel, and cultura
 
 **Trend Categories to Monitor**:
 
-- Sustainability and regenerative travel
-- Wellness and mental health tourism
-- Remote work and digital nomadism
+- Sustainability and market shifts
+- Wellness and consumer lifestyle changes
+- Remote work and digital transformation
 - Cultural celebrations and events
-- Economic shifts affecting travel
-- Technology adoption in hospitality
-- Generational travel preferences
+- Economic shifts affecting the industry
+- Technology adoption in [INDUSTRY]
+- Generational preferences and behaviors
 - Seasonal and cyclical patterns
 
 **Response Requirements**:
@@ -86,7 +86,7 @@ You are a senior trends analyst specializing in hospitality, travel, and cultura
 
 ## Trend Analysis Methodology
 
-- Real-time news monitoring across travel industry publications
+- Real-time news monitoring across [INDUSTRY] publications
 - Social media trend tracking and sentiment analysis
 - Google Trends and search volume analysis
 - Cultural calendar and event monitoring


### PR DESCRIPTION
## Summary
- make Hyatt orchestrator industry agnostic
- genericize agent prompts with placeholders
- pass industry, brand context, and audience information to agents
- update documentation

## Testing
- `npm run lint:styles` *(fails: 345 errors)*

------
https://chatgpt.com/codex/tasks/task_b_687f710eac7c832593a6c63f57b062b7